### PR TITLE
feat(gui): ClusterStats display helper

### DIFF
--- a/playchitect/gui/widgets/cluster_stats.py
+++ b/playchitect/gui/widgets/cluster_stats.py
@@ -173,7 +173,7 @@ class ClusterStats:
             max(s.bpm_max for s in stats),
         )
 
-    def __str__(self) -> str:  # pragma: no cover
+    def __str__(self) -> str:
         return (
             f"[{self.cluster_label}] {self.bpm_range_str} | "
             f"{self.intensity_label} | {self.track_count_str} | {self.duration_str}"


### PR DESCRIPTION
## Summary

- Adds `playchitect/gui/widgets/cluster_stats.py` — pure-Python, GTK-free dataclass
- Computes display-ready values from `ClusterResult` for use in cluster cards
- BPM range string, intensity label/bars, duration string, feature importance ranking
- Cross-cluster normalisation helpers (`bpm_range_fraction`, `global_bpm_range`)
- 51 unit tests, 99% coverage

## Test plan

- [ ] `uv run pytest tests/unit/test_cluster_stats.py -v` — all 51 pass
- [ ] No GTK import in module or tests
- [ ] `from_results([])` returns `[]` (empty list edge case)
- [ ] BPM min clamped to ≥ 1, max always > min

Part of #9