### PR TITLE
feat(cue): CUE timing utilities with frame-accurate conversion

### DIFF
--- a/playchitect/core/cue_timing.py
+++ b/playchitect/core/cue_timing.py
@@ -1,0 +1,90 @@
+"""CUE sheet timing utilities.
+
+CUE sheet time format: MM:SS:FF (minutes, seconds, frames)
+75 frames per second (CD standard, used by all CUE players).
+"""
+
+from __future__ import annotations
+
+_FRAMES_PER_SECOND: int = 75
+
+
+def seconds_to_cue_time(seconds: float) -> str:
+    """Convert a duration in seconds to CUE sheet MM:SS:FF format.
+
+    Negative values are clamped to 0. Rounds to nearest frame.
+
+    Args:
+        seconds: Duration in seconds (float, non-negative)
+
+    Returns:
+        String in "MM:SS:FF" format, e.g. "05:23:00", "00:00:00"
+    """
+    total_frames = int(round(max(0.0, seconds) * _FRAMES_PER_SECOND))
+    frames = total_frames % _FRAMES_PER_SECOND
+    total_seconds = total_frames // _FRAMES_PER_SECOND
+    secs = total_seconds % 60
+    mins = total_seconds // 60
+    return f"{mins:02d}:{secs:02d}:{frames:02d}"
+
+
+def cumulative_offsets(durations: list[float]) -> list[float]:
+    """Return cumulative start-time offsets for a sequence of track durations.
+
+    The first track always starts at 0.0. Each subsequent offset is the sum
+    of all preceding durations.
+
+    Args:
+        durations: List of track durations in seconds.
+
+    Returns:
+        List of float offsets, same length as durations.
+        Empty list if durations is empty.
+
+    Example:
+        cumulative_offsets([300.0, 400.0, 250.0])
+        → [0.0, 300.0, 700.0]
+    """
+    if not durations:
+        return []
+
+    offsets = []
+    current_offset = 0.0
+    for d in durations:
+        offsets.append(current_offset)
+        current_offset += d
+    return offsets
+
+
+def validate_cue_time(time_str: str) -> bool:
+    """Return True if time_str is a valid CUE sheet time (MM:SS:FF).
+
+    Rules:
+        - Exactly 3 colon-separated fields
+        - All fields are non-negative integers (no leading sign)
+        - Seconds field: 0–59
+        - Frames field: 0–74
+        - Minutes field: any non-negative integer
+
+    Args:
+        time_str: String to validate.
+
+    Returns:
+        True if valid, False otherwise.
+    """
+    parts = time_str.split(":")
+    if len(parts) != 3:
+        return False
+
+    for part in parts:
+        if not part.isdigit():
+            return False
+
+    try:
+        mins = int(parts[0])
+        secs = int(parts[1])
+        frames = int(parts[2])
+    except ValueError:
+        return False
+
+    return mins >= 0 and 0 <= secs <= 59 and 0 <= frames <= 74

--- a/tests/unit/test_cue_timing.py
+++ b/tests/unit/test_cue_timing.py
@@ -1,0 +1,99 @@
+"""Unit tests for CUE sheet timing utilities."""
+
+import pytest
+
+from playchitect.core.cue_timing import (
+    cumulative_offsets,
+    seconds_to_cue_time,
+    validate_cue_time,
+)
+
+
+class TestSecondsToTime:
+    def test_zero(self):
+        assert seconds_to_cue_time(0.0) == "00:00:00"
+
+    def test_one_second(self):
+        assert seconds_to_cue_time(1.0) == "00:01:00"
+
+    def test_one_minute(self):
+        assert seconds_to_cue_time(60.0) == "01:00:00"
+
+    def test_large_duration(self):
+        # 3661.0 s = 61 m 1 s 0 f
+        assert seconds_to_cue_time(3661.0) == "61:01:00"
+
+    def test_half_second(self):
+        # round(0.5 * 75) = 38 frames -> "00:00:38"
+        assert seconds_to_cue_time(0.5) == "00:00:38"
+
+    def test_negative_clamped(self):
+        assert seconds_to_cue_time(-10.0) == "00:00:00"
+
+    def test_manual_calc(self):
+        # 386.4 * 75 = 28980.0
+        # 28980 // 75 = 386 s
+        # 386 % 60 = 26 s
+        # 386 // 60 = 6 m
+        # 28980 % 75 = 30 f
+        assert seconds_to_cue_time(386.4) == "06:26:30"
+
+    def test_one_frame(self):
+        # 1/75 s = 1 frame
+        assert seconds_to_cue_time(1 / 75) == "00:00:01"
+
+    def test_rounding_up(self):
+        # round(0.9999 * 75) = 75 frames -> 1 second, 0 frames
+        assert seconds_to_cue_time(0.9999) == "00:01:00"
+
+
+class TestCumulativeOffsets:
+    def test_empty(self):
+        assert cumulative_offsets([]) == []
+
+    def test_single(self):
+        assert cumulative_offsets([300.0]) == [0.0]
+
+    def test_multiple(self):
+        durations = [300.0, 400.0, 250.0]
+        expected = [0.0, 300.0, 700.0]
+        assert cumulative_offsets(durations) == pytest.approx(expected)
+
+    def test_first_is_zero(self):
+        assert cumulative_offsets([123.4, 567.8])[0] == 0.0
+
+    def test_result_length(self):
+        durations = [1.0, 2.0, 3.0, 4.0]
+        assert len(cumulative_offsets(durations)) == len(durations)
+
+
+class TestValidateCueTime:
+    def test_valid_zero(self):
+        assert validate_cue_time("00:00:00") is True
+
+    def test_valid_arbitrary(self):
+        assert validate_cue_time("01:23:45") is True
+
+    def test_valid_max_frames(self):
+        assert validate_cue_time("99:59:74") is True
+
+    def test_invalid_frames_out_of_range(self):
+        assert validate_cue_time("00:00:75") is False
+
+    def test_invalid_seconds_out_of_range(self):
+        assert validate_cue_time("00:60:00") is False
+
+    def test_invalid_alphabetic(self):
+        assert validate_cue_time("abc") is False
+
+    def test_invalid_empty(self):
+        assert validate_cue_time("") is False
+
+    def test_invalid_too_few_fields(self):
+        assert validate_cue_time("00:00") is False
+
+    def test_invalid_too_many_fields(self):
+        assert validate_cue_time("00:00:00:00") is False
+
+    def test_invalid_negative_not_allowed(self):
+        assert validate_cue_time("-1:00:00") is False


### PR DESCRIPTION
Implements the `cue_timing` module as the pure-Python foundation for CUE sheet generation.

## Changes

- `playchitect/core/cue_timing.py`: `seconds_to_cue_time()`, `cumulative_offsets()`, `validate_cue_time()`
- `tests/unit/test_cue_timing.py`: 24 tests covering zero, negatives, frame rounding, range validation

## Details

- 75 frames/second (CD standard)
- Negative seconds clamped to `00:00:00`
- `isdigit()` guard in validator correctly rejects negative signs without needing explicit sign checks
- 94% coverage (`ValueError` branch in `validate_cue_time` is dead code after `isdigit()`)

Part of #11