### PR TITLE
feat(benchmarks): synthetic fixture and component-level benchmarks

### DIFF
--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -10,6 +10,8 @@ from mutagen import File as MutagenFile
 from mutagen.flac import FLAC, FLACNoHeaderError
 from mutagen.id3 import ID3NoHeaderError
 
+SYNTHETIC_SAMPLE_RATE = 22050  # Hz — standard audio sample rate; kept low for smaller files
+
 
 @pytest.fixture(scope="module")
 def synthetic_library(tmp_path_factory: pytest.TempPathFactory):
@@ -20,7 +22,7 @@ def synthetic_library(tmp_path_factory: pytest.TempPathFactory):
 
     def _factory(n_tracks: int, track_duration_seconds: float = 0.5) -> Path:
         base_dir = tmp_path_factory.mktemp(f"synthetic_library_{n_tracks}_tracks")
-        sample_rate = 22050  # Lower sample rate for smaller files and faster processing
+        sample_rate = SYNTHETIC_SAMPLE_RATE
 
         for i in range(n_tracks):
             artist = f"Artist_{random.randint(1, 100)}"


### PR DESCRIPTION
## Summary

- Adds `tests/benchmarks/conftest.py` with a `synthetic_library` factory fixture that generates N tiny FLAC files (0.5 s sine wave + mutagen metadata) so benchmarks always have a target in CI — no real music required
- Refactors `test_fast_perf.py`: `benchmark_target_library` falls back to synthetic when `PLAYCHITECT_BENCH_MUSIC_PATH` is unset
- Adds component-level benchmarks for `AudioScanner`, `MetadataExtractor.extract_batch`, `IntensityAnalyzer.analyze`, and `PlaylistClusterer.cluster_by_features`
- Fixes three API bugs carried over from the draft: single-file `extract` → `extract_batch`; numpy array → real `Path` for `IntensityAnalyzer`; `PlaylistClusterer()` now supplies required `target_tracks_per_playlist`

Closes #53 (synthetic fixture scope), relates to #54 and #56.

## Test plan

- [ ] All 7 benchmark tests pass locally with `--benchmark-disable`
- [ ] Pre-commit hooks (ruff, ty, pytest-unit, cli-smoke-test) all pass
- [ ] CI benchmark step passes without `PLAYCHITECT_BENCH_MUSIC_PATH` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)