### PR TITLE
feat(core): Robust BPM calculation fallback and validation

### DIFF
--- a/playchitect/core/metadata_extractor.py
+++ b/playchitect/core/metadata_extractor.py
@@ -175,7 +175,9 @@ class MetadataExtractor:
                 return True
             if "house" in genre_lower and bpm < 100:
                 return True
-            if ("dnb" in genre_lower or "drum" in genre_lower) and bpm < 150:
+
+            dnb_genres = ("dnb", "drum and bass", "drum & bass", "d&b")
+            if any(g in genre_lower for g in dnb_genres) and bpm < 150:
                 return True
 
         return False


### PR DESCRIPTION
Implement robust BPM handling in .

**Changes:**
- Added BPM calculation fallback using  when metadata tags are missing or 'suspicious'.
- Implemented  logic to detect non-whole numbers (mistakes in electronic music) or genre mismatches (e.g., Techno at 70 BPM).
- Added  method to force fresh metadata extraction/calculation by bypassing the cache.
- Integrated lazy loading for  to maintain lightweight initialization.
- Added comprehensive unit tests for validation and calculation logic.

Closes #65