### PR TITLE
chore(release): prepare v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,95 @@
+# Changelog
+
+All notable changes to Playchitect are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+
+## [1.0.0] — 2026-02-22
+
+First stable release of Playchitect.
+
+### Added
+
+#### Core analysis engine
+- **Intelligent clustering** — K-means on an 8-dimensional feature space: BPM,
+  spectral centroid, high-frequency energy, RMS energy, percussiveness, sub-bass
+  energy, kick energy, and bass harmonics
+- **Librosa intensity analyser** — full STFT-once pipeline with JSON caching and
+  MD5 hash validation; 92% test coverage
+- **Genre-aware multi-clustering** — EWKM per-cluster refinement and genre-specific
+  PCA + EWKM feature weighting
+- **Semantic embeddings** — optional MusiCNN neural embeddings for genre-aware
+  clustering (`[embeddings]` extra)
+- **Smart track selector** — scores tracks for opener/closer suitability (long
+  intros, low intensity, no kick); supports user overrides persisted in config
+- **Robust BPM calculation** — librosa fallback when tags are missing or suspicious
+  (non-whole numbers, genre mismatches); `recalculate()` method to force a cache bypass
+- **Adaptive playlist splitting** — automatically divides clusters to meet a target
+  track count or duration
+
+#### GTK4 desktop application
+- Native GNOME interface built with GTK4 + libadwaita
+- Split-pane main window with scan, analyse, and export controls
+- Track list widget using `Gtk.ColumnView` with sorting and column visibility
+- Cluster visualisation panel
+- Spacebar preview via GNOME Sushi / xdg-open
+
+#### Export & OS integration
+- M3U playlist export
+- CUE sheet generator with frame-accurate timing (75 fps standard)
+- Freedesktop `.desktop` file with MIME associations for M3U and CUE files
+- AppStream metainfo (`com.github.jameswestwood.Playchitect.appdata.xml`)
+- Hicolor icon theme — 9 PNG sizes (16 px → 512 px) generated from source artwork
+- `playchitect-install-desktop` entry point for per-user or system-wide install
+
+#### CLI
+- `playchitect scan <dir>` — analyse and generate playlists
+- `playchitect info <dir>` — show library statistics
+- `--target-tracks`, `--target-duration`, `--dry-run` flags
+- `--use-embeddings`, `--cluster-mode`, feature-weight overrides
+
+#### Packaging & distribution
+- PyPI package — `pip install playchitect` / `uv tool install playchitect`
+- OIDC trusted publishing via GitHub Actions (no long-lived tokens)
+- Self-hosted Flatpak bundle — built by CI and attached to each GitHub Release
+- `playchitect-gui` and `playchitect-install-desktop` entry points
+
+#### Developer tooling
+- Pre-commit hooks: ruff, ty, pytest-unit, cli-smoke-test, GUI smoke tests
+- GitHub Actions CI: lint + type-check + unit tests (Ubuntu Python 3.13, Fedora 41
+  container), extended CLI integration tests, codecov coverage reporting
+- `pytest-benchmark` suite with `synthetic_library` factory fixture; regression
+  alerts via `--benchmark-compare`
+- Gemini 2.5 Pro automated PR review (`scripts/review_pr.sh`)
+
+### Configuration
+
+User settings live at `~/.config/playchitect/config.yaml`. The intensity analysis
+cache defaults to `~/.cache/playchitect/intensity/` and can be overridden via the
+`PLAYCHITECT_CACHE_DIR` environment variable or the `cache_dir` config key.
+
+### Requirements
+
+- Python 3.13+
+- GTK4 GUI requires `python3-gobject` from the OS package manager — not installable
+  via pip. See the README for per-distro instructions.
+
+### Known limitations
+
+- COPR (Fedora DNF) and Flathub packages are not yet available; both are planned
+  post-1.0.0.
+- The `[embeddings]` extra requires `essentia-tensorflow`, which has its own system
+  dependencies; it is not installed by default.
+- `.icns` macOS icon generation is documented but not automated (requires macOS
+  `iconutil`).
+
+---
+
+## [0.1.0] — 2026-02-19
+
+Initial development release. Established project structure, core audio scanner,
+metadata extractor with BPM caching, basic BPM-only clustering, and Click CLI.
+
+[1.0.0]: https://github.com/james-westwood/playchitect/releases/tag/v1.0.0
+[0.1.0]: https://github.com/james-westwood/playchitect/releases/tag/v0.1.0

--- a/data/com.github.jameswestwood.Playchitect.appdata.xml
+++ b/data/com.github.jameswestwood.Playchitect.appdata.xml
@@ -37,9 +37,16 @@
   <url type="bugtracker">https://github.com/james-westwood/playchitect/issues</url>
 
   <releases>
-    <release version="0.1.0" date="2026-02-20">
+    <release version="1.0.0" date="2026-02-22">
       <description>
-        <p>Initial release with core clustering engine and GTK4 GUI.</p>
+        <p>First stable release. Includes the full clustering engine, GTK4 GUI,
+        CUE sheet export, desktop integration, PyPI package, and self-hosted
+        Flatpak bundle.</p>
+      </description>
+    </release>
+    <release version="0.1.0" date="2026-02-19">
+      <description>
+        <p>Initial development release.</p>
       </description>
     </release>
   </releases>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "playchitect"
-version = "0.1.0"
+version = "1.0.0"
 description = "Smart DJ playlist management with intelligent BPM clustering"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "playchitect"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Release preparation for v1.0.0

### Changes

- **`pyproject.toml`**: version bumped `0.1.0` → `1.0.0`
- **`CHANGELOG.md`**: created — covers all features across Milestones 1–6
- **`data/com.github.jameswestwood.Playchitect.appdata.xml`**: v1.0.0 release entry added

### After this merges

1. Create a GitHub Release tagged `v1.0.0` — this automatically triggers the `Publish to PyPI` workflow (OIDC, no tokens needed) and the `Build Flatpak` workflow (bundle attached to the release)
2. The PyPI publishing guide is at `docs/planning/pypi-publishing.md` — the GitHub `pypi` and `testpypi` environments must exist in repo settings before the workflow can run