### PR TITLE
feat(benchmarks): tighten thresholds and add export + perf-report tooling

### DIFF
--- a/scripts/generate_perf_report.py
+++ b/scripts/generate_perf_report.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Generate performance report from benchmark results.
+Updates docs/PERFORMANCE.md with latest benchmark statistics.
+"""
+
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def run_benchmarks(output_json: Path) -> None:
+    """Run pytest-benchmark and save results to JSON."""
+    print(f"Running benchmarks and saving to {output_json}...")
+    cmd = [
+        "uv",
+        "run",
+        "pytest",
+        "tests/benchmarks/test_fast_perf.py",
+        "--benchmark-only",
+        f"--benchmark-json={output_json}",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print("Benchmarks failed!")
+        print(result.stdout)
+        print(result.stderr)
+        sys.exit(1)
+
+
+def generate_markdown(data: dict) -> str:
+    """Generate Markdown report from benchmark data."""
+    report = []
+    report.append("# Playchitect Performance Report")
+    report.append(f"\nGenerated on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+
+    env = data.get("machine_info", {})
+    report.append("\n## Environment")
+    report.append(f"- **CPU**: {env.get('processor', 'Unknown')}")
+    report.append(f"- **Cores**: {env.get('cpu_count', 'Unknown')}")
+    report.append(f"- **OS**: {env.get('system', 'Unknown')} {env.get('release', '')}")
+    report.append(f"- **Python**: {env.get('python_version', 'Unknown')}")
+
+    report.append("\n## Benchmark Results")
+    report.append(
+        "| Test | Mean (ms) | Median (ms) | Min (ms) | Max (ms) | StdDev (ms) | Ops/sec |"
+    )
+    report.append("| :--- | :---: | :---: | :---: | :---: | :---: | :---: |")
+
+    for bench in data.get("benchmarks", []):
+        name = bench["name"].split("::")[-1]
+        stats = bench["stats"]
+        m = 1000.0
+        report.append(
+            f"| {name} | {stats['mean'] * m:.2f} | {stats['median'] * m:.2f} | "
+            f"{stats['min'] * m:.2f} | {stats['max'] * m:.2f} | "
+            f"{stats['stddev'] * m:.2f} | {stats['ops']:.2f} |"
+        )
+
+    return "\n".join(report)
+
+
+def main() -> None:
+    repo_root = Path(__file__).parent.parent
+    output_json = repo_root / ".benchmarks" / "latest_results.json"
+    output_json.parent.mkdir(exist_ok=True)
+
+    perf_md = repo_root / "docs" / "PERFORMANCE.md"
+
+    run_benchmarks(output_json)
+
+    with open(output_json) as f:
+        data = json.load(f)
+
+    markdown = generate_markdown(data)
+
+    with open(perf_md, "w") as f:
+        f.write(markdown)
+
+    print(f"Successfully updated {perf_md}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/test_fast_perf.py
+++ b/tests/benchmarks/test_fast_perf.py
@@ -12,7 +12,8 @@ import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
 from playchitect.core.audio_scanner import AudioScanner
-from playchitect.core.clustering import PlaylistClusterer
+from playchitect.core.clustering import ClusterResult, PlaylistClusterer
+from playchitect.core.export import CUEExporter, M3UExporter
 from playchitect.core.intensity_analyzer import IntensityAnalyzer, IntensityFeatures
 from playchitect.core.metadata_extractor import MetadataExtractor, TrackMetadata
 
@@ -22,11 +23,13 @@ TRACK_SUBSET_SIZE = 100
 
 # Performance thresholds (in seconds)
 # These are used to fail CI if a regression is detected.
-# Values are set to roughly 3-5x the local baseline to allow for CI runner variability.
-THRESHOLD_AUDIO_SCANNER = 0.050  # 50ms for 50 tracks
-THRESHOLD_METADATA_EXTRACTOR = 0.100  # 100ms for 50 tracks
-THRESHOLD_INTENSITY_ANALYZER = 0.200  # 200ms for one 0.5s file
-THRESHOLD_CLUSTERING = 1.0  # 1s for 1000 tracks
+# Values are set to roughly 2-3x the local baseline to allow for CI runner variability.
+THRESHOLD_AUDIO_SCANNER = 0.010  # 10ms for 50 tracks
+THRESHOLD_METADATA_EXTRACTOR = 0.050  # 50ms for 50 tracks
+THRESHOLD_INTENSITY_ANALYZER = 0.100  # 100ms for one 0.5s file
+THRESHOLD_CLUSTERING = 0.800  # 800ms for 1000 tracks
+THRESHOLD_M3U_EXPORT = 0.050  # 50ms for 50 tracks
+THRESHOLD_CUE_EXPORT = 0.050  # 50ms for 50 tracks
 THRESHOLD_CLI_INFO = 10.0  # 10s for 10 tracks (uv run overhead in CI)
 THRESHOLD_CLI_SCAN = 12.0  # 12s for 10 tracks
 
@@ -181,3 +184,45 @@ class TestFastPerformanceChecks:
             use_ewkm=False,
         )
         assert benchmark.stats.stats.mean < THRESHOLD_CLUSTERING  # type: ignore
+
+    def test_m3u_export(self, benchmark: BenchmarkFixture, tmp_path: Path):
+        """Benchmark M3U playlist export performance."""
+        num_tracks = 50
+        paths = [Path(f"/path/to/track_{i}.flac") for i in range(num_tracks)]
+        cluster = ClusterResult(
+            cluster_id=0,
+            tracks=paths,
+            bpm_mean=120.0,
+            bpm_std=2.0,
+            track_count=num_tracks,
+            total_duration=num_tracks * 180.0,
+        )
+        metadata_dict = {
+            p: TrackMetadata(filepath=p, artist="Artist", title=f"Track {i}", duration=180.0)
+            for i, p in enumerate(paths)
+        }
+
+        exporter = M3UExporter(output_dir=tmp_path)
+        benchmark(exporter.export_clusters, [cluster], metadata_dict=metadata_dict)
+        assert benchmark.stats.stats.mean < THRESHOLD_M3U_EXPORT  # type: ignore
+
+    def test_cue_export(self, benchmark: BenchmarkFixture, tmp_path: Path):
+        """Benchmark CUE sheet export performance."""
+        num_tracks = 50
+        paths = [Path(f"/path/to/track_{i}.flac") for i in range(num_tracks)]
+        cluster = ClusterResult(
+            cluster_id=0,
+            tracks=paths,
+            bpm_mean=120.0,
+            bpm_std=2.0,
+            track_count=num_tracks,
+            total_duration=num_tracks * 180.0,
+        )
+        metadata_dict = {
+            p: TrackMetadata(filepath=p, artist="Artist", title=f"Track {i}", duration=180.0)
+            for i, p in enumerate(paths)
+        }
+
+        exporter = CUEExporter(output_dir=tmp_path)
+        benchmark(exporter.export_clusters, [cluster], metadata_dict=metadata_dict)
+        assert benchmark.stats.stats.mean < THRESHOLD_CUE_EXPORT  # type: ignore


### PR DESCRIPTION
## Summary

- Tighten performance thresholds from 3-5x to 2-3x local baseline for more sensitive regression detection
- Add M3U and CUE export benchmarks to the fast-perf suite
- Add `scripts/generate_perf_report.py` — run to snapshot benchmark results as `docs/PERFORMANCE.md`

## Test plan

- [ ] `uv run pytest tests/benchmarks/ --benchmark-only` passes with new thresholds
- [ ] `python scripts/generate_perf_report.py` produces `docs/PERFORMANCE.md`
- [ ] CI green