### PR TITLE
chore(security): add detect-secrets pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,13 @@ repos:
         pass_filenames: false
         always_run: false
 
+  # Detect accidental secret commits
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: [--baseline, .secrets.baseline]
+
   # Standard file hygiene
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,146 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "tests/unit/test_embedding_extractor.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/test_embedding_extractor.py",
+        "hashed_secret": "f538b12b42468087bffe54648a82be1f6baddde7",
+        "is_verified": false,
+        "line_number": 818,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/test_embedding_extractor.py",
+        "hashed_secret": "578edbb844fd4912c73eb3e9899ded01f6e78ca9",
+        "is_verified": false,
+        "line_number": 829,
+        "is_secret": false
+      }
+    ]
+  },
+  "generated_at": "2026-02-23T19:05:46Z"
+}


### PR DESCRIPTION
## Summary
- Adds `detect-secrets` v1.5.0 to the pre-commit pipeline to prevent accidental secret commits
- Generates `.secrets.baseline` from the current codebase (clean)
- Two false positives in `tests/unit/test_embedding_extractor.py` audited and marked: `deadbeefcafe1234` and `cafe1234deadbeef` are fake MD5-style file hash fixtures, not real credentials

## Notes
When adding new high-entropy test fixtures in future, update the baseline with:
```bash
detect-secrets scan --baseline .secrets.baseline
git add .secrets.baseline
```