### PR TITLE
docs(vitepress): link Roadmap in nav and sidebar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -18,6 +18,7 @@ export default withMermaid(defineConfig({
 
     nav: [
       { text: 'User Guide', link: '/guide/' },
+      { text: 'Roadmap', link: '/planning/ROADMAP' },
       { text: 'Contributing', link: '/contributing/' },
       {
         text: 'GitHub',
@@ -34,6 +35,7 @@ export default withMermaid(defineConfig({
             { text: 'Installation', link: '/guide/installation' },
             { text: 'Quick Start', link: '/guide/quick-start' },
             { text: 'CLI Reference', link: '/guide/cli-reference' },
+            { text: 'Development Roadmap', link: '/planning/ROADMAP' },
           ]
         }
       ],


### PR DESCRIPTION
## Summary
Links the Development Roadmap in the top navigation bar and the User Guide sidebar to make it easily discoverable on the documentation site.

## Changes
- Added 'Roadmap' to the top `nav`.
- Added 'Development Roadmap' to the `/guide/` sidebar.