### PR TITLE
chore(prd): add GitHub issues #82 and #84 as tasks

### DIFF
--- a/prd.json
+++ b/prd.json
@@ -381,6 +381,28 @@
       "note": "GitHub issue #87"
     },
     {
+      "id": "TASK-29",
+      "epic": "DJ Ecosystem Integration",
+      "title": "audio_structural_analysis_cue_injection",
+      "owner": "ralph",
+      "description": "Implement audio structural analysis to predict mix points and inject cues into Mixxx. (1) Create playchitect/core/structural_analyzer.py. Implement `StructuralAnalyzer` with `analyze(filepath: Path, metadata: TrackMetadata) -> StructuralAnalysis` where `StructuralAnalysis` is a dataclass with fields: `intro_end_ms: float`, `outro_start_ms: float`, `breakdowns: list[float]`, `drops: list[float]`. Use librosa to detect energy-based boundaries: compute RMS energy with `librosa.feature.rms`, find the first frame where energy exceeds 20% of peak (intro end), find the last frame where energy exceeds 20% of peak (outro start). Detect drops as local maxima in the RMS envelope above the 75th percentile. (2) Implement `predict_cue_points(analysis: StructuralAnalysis) -> dict[str, float]` returning `{'cue_1_ms': intro_end_ms, 'cue_2_ms': outro_start_ms}`. (3) In `MixxxSync` (mixxx_sync.py), add `write_cue_points(db_path: Path, track_path: Path, cue_points: dict[str, float]) -> int` that inserts/replaces rows in the `cues` table (`type=1` for hot cues): `INSERT OR REPLACE INTO cues (track_id, type, position, length, hotcue, label) VALUES (?, 1, ?, 0, ?, ?)` where position is in samples at 44100 Hz. (4) In `TrackPreviewPanel` (track_preview_panel.py), add an 'Apply Suggested Cues' `Gtk.Button` that calls `StructuralAnalyzer().analyze()` then `write_cue_points()` in a background thread; show a spinner while running and a toast on completion. (5) Add unit tests in tests/unit/test_structural_analyzer.py using synthetic audio fixtures.",
+      "acceptance_criteria": "tests/unit/test_structural_analyzer.py: analyze() on a synthetic audio fixture returns a StructuralAnalysis with intro_end_ms and outro_start_ms as positive floats. predict_cue_points returns a dict with 'cue_1_ms' and 'cue_2_ms'. write_cue_points on an in-memory Mixxx DB inserts rows into the cues table. `uv run pytest tests/ -v` passes.",
+      "completed": false,
+      "priority": 7,
+      "note": "GitHub issue #82. Relates to #79, #81 (Mixxx sync)."
+    },
+    {
+      "id": "TASK-H2",
+      "epic": "Integrations — Research",
+      "title": "realtime_next_track_sidecar_feasibility",
+      "owner": "human",
+      "description": "Research and decide on the feasibility of a real-time 'Next Track' sidecar integration with Mixxx. Concept: a bridge between Mixxx's active performance and Playchitect's sequencing logic. As a set plays in Mixxx, Playchitect updates its view in real-time to show current position in the ramp and recommends next tracks based on live energy. Potential path: Mixxx JavaScript controller script broadcasts current track metadata via local WebSocket or OSC; Playchitect listens and highlights 'Now Playing'; dynamic re-sequencing if the DJ deviates from the architected plan. This is a research/decision task — evaluate the Mixxx controller scripting API, WebSocket/OSC feasibility, and decide whether to build a spike or shelve.",
+      "acceptance_criteria": "Human decision: either a GitHub comment on #84 with a go/no-go verdict and rough technical plan, or a new task added to prd.json for the implementation spike.",
+      "completed": false,
+      "priority": 9,
+      "note": "GitHub issue #84. Labelled 'out-of-the-box' — ambitious idea, needs human judgement before ralph can act."
+    },
+    {
       "id": "TASK-H1",
       "epic": "Distribution",
       "title": "flathub_submission",


### PR DESCRIPTION
## Summary

- Adds **TASK-29**: Audio structural analysis & cue injection (ralph-owned, issue #82) — `StructuralAnalyzer` using librosa RMS energy, Mixxx DB cue point writing, and a GUI button in `TrackPreviewPanel`
- Adds **TASK-H2**: Real-time next-track sidecar feasibility (human-owned, issue #84) — research/decision task before any implementation

## Test plan

- [ ] prd.json is valid JSON: `python3 -m json.tool prd.json`
- [ ] Both new tasks appear before TASK-H1 in priority order