### PR TITLE
fix(tests): prevent network download in test_mean_pooling_is_correct

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "tests/unit/test_embedding_extractor.py",
         "hashed_secret": "f538b12b42468087bffe54648a82be1f6baddde7",
         "is_verified": false,
-        "line_number": 1052,
+        "line_number": 1056,
         "is_secret": false
       },
       {
@@ -141,10 +141,10 @@
         "filename": "tests/unit/test_embedding_extractor.py",
         "hashed_secret": "578edbb844fd4912c73eb3e9899ded01f6e78ca9",
         "is_verified": false,
-        "line_number": 1063,
+        "line_number": 1067,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-02-23T22:54:46Z"
+  "generated_at": "2026-04-11T09:51:02Z"
 }

--- a/tests/unit/test_embedding_extractor.py
+++ b/tests/unit/test_embedding_extractor.py
@@ -465,8 +465,12 @@ class TestEmbeddingExtractorAnalysis:
         meta_file = tmp_path / "fake.json"
         meta_file.write_text(json.dumps({"classes": [str(i) for i in range(50)]}))
 
+        mood_model_file = tmp_path / "fake_mood.pb"
+        mood_model_file.write_bytes(b"x")
+
         extractor = EmbeddingExtractor(
             model_path=model_file,
+            mood_model_path=mood_model_file,
             cache_enabled=False,
         )
 


### PR DESCRIPTION
## Summary

- `test_mean_pooling_is_correct` constructed `EmbeddingExtractor` with only `model_path` set
- `mood_model_path` defaulted to `~/.cache/playchitect/models/moods_mirex-msd-musicnn-1.pb`, which does not exist in CI
- `_ensure_model()` then attempted a live download, timing out and failing the test with `Connection timed out`

Fix: pass a fake `mood_model_path` that already exists in `tmp_path`, matching the pattern used by every other fixture in `TestEmbeddingExtractorAnalysis`.

## Test plan

- [ ] `uv run pytest tests/unit/test_embedding_extractor.py::TestEmbeddingExtractorAnalysis::test_mean_pooling_is_correct -v` passes without network access
- [ ] No other tests are affected