### PR TITLE
[TASK-29] vibe_profiling_salience_scoring

### DIFF
--- a/playchitect/core/naming/vibe_profiler.py
+++ b/playchitect/core/naming/vibe_profiler.py
@@ -13,6 +13,7 @@ import numpy as np
 if TYPE_CHECKING:
     from playchitect.core.clustering import ClusterResult
     from playchitect.core.intensity_analyzer import IntensityFeatures
+    from playchitect.core.metadata_extractor import TrackMetadata
 
 # BPM bucketing thresholds
 _BPM_SLOW_THRESHOLD: float = 100.0
@@ -56,6 +57,7 @@ class VibeProfile:
 def compute_vibe_profile(
     cluster: "ClusterResult",
     features: dict[Path, "IntensityFeatures"],
+    metadata: dict[Path, "TrackMetadata"] | None = None,
 ) -> VibeProfile:
     """Compute vibe profile for a cluster.
 
@@ -65,6 +67,7 @@ def compute_vibe_profile(
     Args:
         cluster: ClusterResult containing tracks and basic stats
         features: Mapping of file path → IntensityFeatures
+        metadata: Optional mapping of file path → TrackMetadata (for API compliance)
 
     Returns:
         VibeProfile with averaged features and mood distribution

--- a/progress.txt
+++ b/progress.txt
@@ -31,3 +31,4 @@
 [2026-03-15] [TASK-25] mixxx_bidirectional_sync: implemented and merged (PR #154)
 [2026-03-15] [TASK-26] rekordbox_xml_import: implemented and merged (PR #155)
 [2026-03-15] [TASK-28] vibe_tags_annotation: implemented and merged (PR #156)
+[2026-04-11] [TASK-29] vibe_profiling_salience_scoring: Updated compute_vibe_profile signature to include optional metadata parameter for API compliance; all tests pass


### PR DESCRIPTION
## [TASK-29] vibe_profiling_salience_scoring

**Epic:** Intelligent Playlist Naming
**Coder:** `kimi-k2.5` | **Reviewer:** `glm-5.1`

### Description
Implement vibe profiling and salience scoring as data layer for playlist naming. (1) Create playchitect/core/naming/__init__.py and playchitect/core/naming/vibe_profiler.py. Define `VibeProfile` dataclass: `cluster_id: int`, `mean_bpm: float`, `mean_rms: float`, `mean_brightness: float`, `mean_percussiveness: float`, `mean_vocal_presence: float`, `dominant_mood: str`, `mood_distribution: dict[str, float]` (mood → fraction of tracks). Implement `compute_vibe_profile(cluster: ClusterResult, features: dict[Path, IntensityFeatures], metadata: dict[Path, TrackMetadata]) -> VibeProfile`: average each feature field across all tracks in the cluster; compute `dominant_mood` as the most frequent `mood_label` across tracks. Implement `score_salience(profile: VibeProfile, library_profiles: list[VibeProfile]) -> dict[str, float]`: compute library mean and std for mean_bpm, mean_rms, mean_brightness, mean_percussiveness, mean_vocal_presence; return a dict mapping feature_name → z-score for this profile; only return entries with abs(z) > 1.5. Add `bucket_bpm(bpm: float) -> str`: <100='Slow', 100–120='Mid-Tempo', 120–135='Peak Hour', >135='High Energy'. Add `bucket_energy(rms: float) -> str`: <0.3='Subtle', 0.3–0.5='Groovy', 0.5–0.7='Energetic', >0.7='Intense'. Add unit tests.

### Acceptance Criteria
tests/unit/test_vibe_profiler.py: compute_vibe_profile on a 3-track cluster returns correct mean_bpm. score_salience returns empty dict when all profiles are identical. bucket_bpm(125) == 'Peak Hour'. bucket_energy(0.8) == 'Intense'. `uv run pytest tests/ -v` passes.

---
*Ralph Loop — multi-agent AI pair programming*