### PR TITLE
[FIX-04] fix_vorbis_valueerror_in_extract_text_tag

### DIFF
--- a/playchitect/core/metadata_extractor.py
+++ b/playchitect/core/metadata_extractor.py
@@ -298,20 +298,28 @@ class MetadataExtractor:
             Tag value as string, or None if not found
         """
         for tag in tag_names:
-            if tag in audio:
-                value = audio[tag]
-
-                # Handle list values
-                if isinstance(value, list) and len(value) > 0:
-                    value = value[0]
-
-                # Convert to string
-                try:
-                    text = str(value).strip()
-                    if text:
-                        return text
-                except Exception:
+            # Wrap tag lookup in try/except to handle Vorbis comment ValueError
+            # mutagen's __contains__ can trigger __getitem__ which raises ValueError
+            try:
+                if tag in audio:
+                    value = audio[tag]
+                else:
                     continue
+            except (ValueError, KeyError):
+                # Silently skip tags that cause mutagen errors (e.g., Vorbis FLAC)
+                continue
+
+            # Handle list values
+            if isinstance(value, list) and len(value) > 0:
+                value = value[0]
+
+            # Convert to string
+            try:
+                text = str(value).strip()
+                if text:
+                    return text
+            except Exception:
+                continue
 
         return None
 

--- a/prd.json
+++ b/prd.json
@@ -13,7 +13,7 @@
       "owner": "ralph",
       "description": "In playchitect/core/metadata_extractor.py, _extract_text_tag() uses `if tag in audio` (line ~301) which triggers mutagen's __contains__ -> __getitem__ -> ValueError on Vorbis-comment FLAC files. Wrap the tag lookup in a try/except: replace `if tag in audio: value = audio[tag]` with a try/except (ValueError, KeyError) block that continues to the next tag name on exception. This silences the spurious bare ValueError and allows extraction to complete for genre, mood, and any other tags that follow.",
       "acceptance_criteria": "tests/unit/test_metadata_extractor.py: add a test where a mock mutagen object's __contains__ raises ValueError; assert _extract_text_tag returns None instead of propagating. Scanning a FLAC library no longer logs \"Error extracting metadata from ...:\" with an empty message. uv run pytest tests/ -v passes.",
-      "completed": false,
+      "completed": true,
       "priority": 1,
       "note": "GitHub issue #176"
     },

--- a/progress.txt
+++ b/progress.txt
@@ -32,3 +32,4 @@
 [2026-03-15] [TASK-26] rekordbox_xml_import: implemented and merged (PR #155)
 [2026-03-15] [TASK-28] vibe_tags_annotation: implemented and merged (PR #156)
 [2026-04-11] [TASK-32] audio_structural_analysis_cue_injection: implemented structural analysis with librosa RMS energy detection, Mixxx cue injection, and GUI integration with spinner/toast feedback
+[2026-04-11] [FIX-04] fix_vorbis_valueerror_in_extract_text_tag: wrapped tag lookup in try/except (ValueError, KeyError) to handle Vorbis-comment FLAC files; added test verifying _extract_text_tag returns None instead of propagating

--- a/tests/unit/test_metadata_extractor.py
+++ b/tests/unit/test_metadata_extractor.py
@@ -434,6 +434,55 @@ class TestMetadataExtractor:
         extractor = MetadataExtractor()
         assert extractor._extract_text_tag(MockAudio(), ["artist"]) is None
 
+    def test_extract_text_tag_vorbis_valueerror(self):
+        """Test _extract_text_tag handles ValueError from mutagen __contains__ (FIX-04).
+
+        Vorbis-comment FLAC files can trigger ValueError when mutagen's __contains__
+        calls __getitem__ internally. This should be caught and extraction should
+        continue to the next tag name.
+        """
+
+        class VorbisMockAudio:
+            """Mock that raises ValueError on __contains__ like some Vorbis files."""
+
+            def __init__(self, value_error_tags: set[str], good_tags: dict[str, str]):
+                self.value_error_tags = value_error_tags
+                self.good_tags = good_tags
+
+            def __contains__(self, key):
+                if key in self.value_error_tags:
+                    raise ValueError("Vorbis comment error")
+                return key in self.good_tags
+
+            def __getitem__(self, key):
+                if key in self.value_error_tags:
+                    raise ValueError("Vorbis comment error")
+                return [self.good_tags[key]]
+
+        extractor = MetadataExtractor()
+
+        # Test: ValueError on first tag, should continue to second
+        mock = VorbisMockAudio(value_error_tags={"genre"}, good_tags={"TCON": "Techno"})
+        result = extractor._extract_text_tag(mock, ["genre", "TCON", "\xa9gen"])
+        assert result == "Techno"
+
+        # Test: ValueError on all tags should return None
+        mock_all_bad = VorbisMockAudio(value_error_tags={"genre", "TCON", "\xa9gen"}, good_tags={})
+        result = extractor._extract_text_tag(mock_all_bad, ["genre", "TCON", "\xa9gen"])
+        assert result is None
+
+        # Test: KeyError should also be handled
+        class KeyErrorMockAudio:
+            def __contains__(self, key):
+                raise KeyError("Missing key")
+
+            def __getitem__(self, key):
+                raise KeyError("Missing key")
+
+        mock_keyerror = KeyErrorMockAudio()
+        result = extractor._extract_text_tag(mock_keyerror, ["artist", "title"])
+        assert result is None
+
     def test_extract_batch_progress_log(self, monkeypatch):
         """Test batch progress logging (line 317)."""
         extractor = MetadataExtractor()


### PR DESCRIPTION
## [FIX-04] fix_vorbis_valueerror_in_extract_text_tag

**Epic:** Stability
**Coder:** `kimi-k2.5` | **Reviewer:** `glm-5.1`

### Description
In playchitect/core/metadata_extractor.py, _extract_text_tag() uses `if tag in audio` (line ~301) which triggers mutagen's __contains__ -> __getitem__ -> ValueError on Vorbis-comment FLAC files. Wrap the tag lookup in a try/except: replace `if tag in audio: value = audio[tag]` with a try/except (ValueError, KeyError) block that continues to the next tag name on exception. This silences the spurious bare ValueError and allows extraction to complete for genre, mood, and any other tags that follow.

### Acceptance Criteria
tests/unit/test_metadata_extractor.py: add a test where a mock mutagen object's __contains__ raises ValueError; assert _extract_text_tag returns None instead of propagating. Scanning a FLAC library no longer logs "Error extracting metadata from ...:" with an empty message. uv run pytest tests/ -v passes.

---
*Ralph Loop — multi-agent AI pair programming*