### PR TITLE
chore(ralph): add Closes keyword to PR body when task has GitHub issue

### DIFF
--- a/ralph-once.sh
+++ b/ralph-once.sh
@@ -71,6 +71,21 @@ TASK_TITLE=$(next_task_field title "$FORCED_TASK_ID")
 TASK_DESC=$(next_task_field description "$FORCED_TASK_ID")
 TASK_AC=$(next_task_field acceptance_criteria "$FORCED_TASK_ID")
 TASK_EPIC=$(next_task_field epic "$FORCED_TASK_ID")
+TASK_NOTE=$(python3 -c "
+import json
+with open('prd.json') as f: prd = json.load(f)
+if '$FORCED_TASK_ID':
+    t = next(x for x in prd['tasks'] if x['id'] == '$FORCED_TASK_ID')
+else:
+    t = [x for x in prd['tasks'] if not x['completed'] and x.get('owner') != 'human'][0]
+print(t.get('note', ''))
+" 2>/dev/null || true)
+
+# Extract GitHub issue number from note field (e.g. "GitHub issue #176" -> "176")
+CLOSES_LINE=""
+if [[ "$TASK_NOTE" =~ \#([0-9]+) ]]; then
+  CLOSES_LINE="Closes #${BASH_REMATCH[1]}"
+fi
 
 # Check if human-owned (only relevant when auto-picking)
 if [[ -z "$FORCED_TASK_ID" ]]; then
@@ -156,7 +171,8 @@ $TASK_DESC
 
 ### Acceptance Criteria
 $TASK_AC
-
+${CLOSES_LINE:+
+$CLOSES_LINE}
 ---
 *Ralph Loop — multi-agent AI pair programming*
 EOF


### PR DESCRIPTION
Extracts the issue number from the prd.json `note` field and appends `Closes #NNN` to the PR body so GitHub auto-closes the linked issue on merge.

Previously issues had to be closed manually after PRs merged. Now any task with a `note` like `"GitHub issue #176"` will get a `Closes #176` line in the PR body automatically.