### PR TITLE
[BUG-05] fix_layout_overflow_and_column_resizing

### DIFF
--- a/playchitect/gui/app.py
+++ b/playchitect/gui/app.py
@@ -10,10 +10,18 @@ from gi.repository import Adw, Gtk  # type: ignore[unresolved-import]
 from playchitect.gui.windows.main_window import PlaychitectWindow
 
 
+def _configure_titlebar_double_click() -> None:
+    """Configure titlebar double-click to maximize window (default is toggle-maximize)."""
+    settings = Gtk.Settings.get_default()
+    if settings is not None:
+        settings.set_property("gtk-titlebar-double-click", "toggle-maximize")
+
+
 class PlaychitectApplication(Adw.Application):
     def __init__(self, **kwargs):
         super().__init__(application_id="com.github.jameswestwood.Playchitect", **kwargs)
         Gtk.Window.set_default_icon_name("com.github.jameswestwood.Playchitect")
+        _configure_titlebar_double_click()
         self.connect("activate", self.on_activate)
 
     def on_activate(self, app):

--- a/playchitect/gui/views/library_view.py
+++ b/playchitect/gui/views/library_view.py
@@ -259,9 +259,11 @@ class LibraryView(Gtk.Box):
 
     def _build_column_view(self) -> None:
         """Build the ColumnView with track columns."""
-        scroll = Gtk.ScrolledWindow()
-        scroll.set_vexpand(True)
-        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        self._scroll = Gtk.ScrolledWindow()
+        self._scroll.set_vexpand(True)
+        self._scroll.set_hexpand(True)
+        self._scroll.set_max_content_width(1200)
+        self._scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 
         self._column_view = Gtk.ColumnView(model=self._selection)
         self._column_view.set_show_row_separators(True)
@@ -290,8 +292,7 @@ class LibraryView(Gtk.Box):
             col = Gtk.ColumnViewColumn(title=header, factory=factory)
             col.set_fixed_width(width)
             col.set_resizable(True)
-            if header == "Title":
-                col.set_expand(True)
+            col.set_expand(header == "Title")
 
             if sort_attr:
                 col.set_sorter(Gtk.CustomSorter.new(_compare_tracks(sort_attr), None))
@@ -301,8 +302,8 @@ class LibraryView(Gtk.Box):
         # Wire sorter
         self._sort_model.set_sorter(self._column_view.get_sorter())
 
-        scroll.set_child(self._column_view)
-        self.append(scroll)
+        self._scroll.set_child(self._column_view)
+        self.append(self._scroll)
 
     def _bind_title(self, _factory: Gtk.SignalListItemFactory, item: Gtk.ListItem) -> None:
         """Bind title column."""

--- a/playchitect/gui/views/playlists_view.py
+++ b/playchitect/gui/views/playlists_view.py
@@ -154,6 +154,7 @@ class PlaylistsView(Gtk.Box):
     def _build_toolbar(self) -> None:
         """Build the top ActionBar toolbar."""
         self._action_bar = Gtk.ActionBar()
+        self._action_bar.set_hexpand(False)
 
         # Left: Generate Playlists button (primary style)
         self._generate_btn = Gtk.Button(label="Generate Playlists")
@@ -164,6 +165,7 @@ class PlaylistsView(Gtk.Box):
         # Left: Playlist size controls box
         controls_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
         controls_box.set_margin_start(12)
+        controls_box.set_hexpand(False)
 
         # Size value SpinButton with label
         size_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
@@ -208,6 +210,7 @@ class PlaylistsView(Gtk.Box):
         # Center: Harmonic mixing control
         harmonic_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         harmonic_box.set_margin_start(12)
+        harmonic_box.set_hexpand(False)
         harmonic_label = Gtk.Label(label="Harmonic mixing")
         harmonic_box.append(harmonic_label)
 
@@ -231,6 +234,7 @@ class PlaylistsView(Gtk.Box):
         # Center: Sort by control (TASK-12)
         sort_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         sort_box.set_margin_start(12)
+        sort_box.set_hexpand(False)
         sort_label = Gtk.Label(label="Sort by:")
         sort_box.append(sort_label)
 
@@ -254,6 +258,7 @@ class PlaylistsView(Gtk.Box):
         # TASK-14: Timbre similarity scale
         timbre_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         timbre_box.set_margin_start(12)
+        timbre_box.set_hexpand(False)
         timbre_label = Gtk.Label(label="Timbre similarity:")
         timbre_box.append(timbre_label)
 
@@ -274,6 +279,7 @@ class PlaylistsView(Gtk.Box):
         # TASK-16: Vocal filter chips
         vocal_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         vocal_box.set_margin_start(12)
+        vocal_box.set_hexpand(False)
         vocal_label = Gtk.Label(label="Vocals:")
         vocal_box.append(vocal_label)
 
@@ -300,6 +306,7 @@ class PlaylistsView(Gtk.Box):
         # Issue #39: Energy flow dropdown
         energy_flow_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         energy_flow_box.set_margin_start(12)
+        energy_flow_box.set_hexpand(False)
         energy_flow_label = Gtk.Label(label="Energy flow:")
         energy_flow_box.append(energy_flow_label)
 

--- a/playchitect/gui/widgets/track_preview_panel.py
+++ b/playchitect/gui/widgets/track_preview_panel.py
@@ -138,6 +138,10 @@ class TrackPreviewPanel(Gtk.Box):
         self.set_margin_end(12)
         self.set_margin_top(12)
         self.set_margin_bottom(12)
+        self.set_hexpand(False)
+        self.set_vexpand(False)
+        self.set_size_request(280, -1)
+        self.set_valign(Gtk.Align.START)
 
         # State
         self._current_track: LibraryTrackModel | None = None

--- a/playchitect/gui/windows/main_window.py
+++ b/playchitect/gui/windows/main_window.py
@@ -292,7 +292,7 @@ class PlaychitectWindow(Adw.ApplicationWindow):
         library_paned.set_start_child(self._library_view)
         library_paned.set_end_child(self._track_preview)
         library_paned.set_shrink_end_child(False)
-        library_paned.set_position(600)
+        library_paned.set_position(700)
         stack.add_titled(library_paned, "library", "Library")
 
         # Playlists view (using new PlaylistsView)


### PR DESCRIPTION
## [BUG-05] fix_layout_overflow_and_column_resizing

**Epic:** GUI Stability
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Multiple views overflow the screen width: Library view is too wide even with no tracks; Preview panel is too wide; Playlists view overflows due to the number of controls in the action bar. Also, columns in the Library ColumnView are not resizable (Gtk.ColumnViewColumn.set_resizable is not set to True). Fix: (1) Set max-width / hexpand=False constraints on panels and action bars. (2) Set resizable=True on all ColumnViewColumn instances in LibraryView. (3) Make the app window double-click-maximisable (check Adw.ApplicationWindow title bar settings). (4) Ensure the Playlists action bar controls wrap or collapse on narrow windows.

### Acceptance Criteria
App fits within a 1920x1080 display without horizontal scrollbars. Library columns are draggable to resize. Double-clicking the title bar maximises the window. uv run pytest tests/ -v passes.

---
*Ralph Loop — multi-agent AI pair programming*