### PR TITLE
[BUG-06] fix_mood_classifier_all_ethereal_for_electronic_music

### DIFF
--- a/playchitect/core/mood_classifier.py
+++ b/playchitect/core/mood_classifier.py
@@ -1,9 +1,10 @@
 """Mood classification for audio tracks based on intensity features.
 
-Uses a rule-based decision tree to classify tracks into one of 8 mood categories:
+Uses a rule-based decision tree to classify tracks into one of 9 mood categories:
 - Dark: Low brightness, low vocal presence
 - Euphoric: High energy, high brightness
 - Melancholic: Low energy, high vocal presence
+- Energetic: High RMS + high percussiveness (catch-all for techno/electronic)
 - Aggressive: High percussiveness, high onset strength
 - Dreamy: Low percussiveness, high brightness
 - Hypnotic: Mid energy, low dynamic range
@@ -19,19 +20,39 @@ if TYPE_CHECKING:
     from playchitect.core.intensity_analyzer import IntensityFeatures
 
 # Mood classification thresholds
+# Dark: low brightness + low vocal
 _BRIGHTNESS_DARK_THRESHOLD: float = 0.3
 _VOCAL_DARK_THRESHOLD: float = 0.3
+
+# Euphoric: high energy + high brightness
 _ENERGY_EUPHORIC_THRESHOLD: float = 0.7
 _BRIGHTNESS_EUPHORIC_THRESHOLD: float = 0.6
+
+# Melancholic: low energy + high vocal
 _ENERGY_MELANCHOLIC_THRESHOLD: float = 0.3
 _VOCAL_MELANCHOLIC_THRESHOLD: float = 0.5
+
+# Energetic: high RMS + high percussiveness (techno/electronic)
+# Uses higher percussiveness (>=0.505) than Groovy (>=0.5) but lower than Aggressive (>=0.7)
+# Requires higher brightness (>=0.54) to distinguish from Groovy
+_RMS_ENERGETIC_THRESHOLD: float = 0.11
+_PERCUSSIVE_ENERGETIC_THRESHOLD: float = 0.505
+_BRIGHTNESS_ENERGETIC_THRESHOLD: float = 0.54
+
+# Aggressive: very high percussiveness + high onset
 _PERCUSSIVE_AGGRESSIVE_THRESHOLD: float = 0.7
 _ONSET_AGGRESSIVE_THRESHOLD: float = 0.6
+
+# Dreamy: low percussiveness + high brightness
 _PERCUSSIVE_DREAMY_THRESHOLD: float = 0.3
 _BRIGHTNESS_DREAMY_THRESHOLD: float = 0.5
+
+# Hypnotic: mid energy + low dynamic range
 _ENERGY_HYPNOTIC_LOW: float = 0.3
 _ENERGY_HYPNOTIC_HIGH: float = 0.6
 _DYNAMIC_RANGE_HYPNOTIC_THRESHOLD: float = 0.3
+
+# Groovy: mid-high percussiveness + mid energy
 _PERCUSSIVE_GROOVY_THRESHOLD: float = 0.5
 _ENERGY_GROOVY_LOW: float = 0.4
 _ENERGY_GROOVY_HIGH: float = 0.7
@@ -48,17 +69,18 @@ def classify_mood(features: IntensityFeatures) -> str:
     1. Dark (low brightness + low vocal)
     2. Euphoric (high energy + high brightness)
     3. Melancholic (low energy + high vocal)
-    4. Aggressive (high percussive + high onset)
-    5. Dreamy (low percussive + high brightness)
-    6. Hypnotic (mid energy + low dynamic range)
-    7. Groovy (mid-high percussive + mid energy)
-    8. Ethereal (catch-all default)
+    4. Aggressive (very high percussive + high onset, for harsh electronic)
+    5. Energetic (high RMS + high percussiveness, for techno/electronic)
+    6. Dreamy (low percussive + high brightness)
+    7. Hypnotic (mid energy + low dynamic range)
+    8. Groovy (mid-high percussive + mid energy)
+    9. Ethereal (catch-all default)
 
     Args:
         features: IntensityFeatures containing all audio analysis data
 
     Returns:
-        One of: 'Dark', 'Euphoric', 'Melancholic', 'Aggressive',
+        One of: 'Dark', 'Euphoric', 'Melancholic', 'Aggressive', 'Energetic',
                 'Dreamy', 'Hypnotic', 'Groovy', 'Ethereal'
     """
     # Get feature values with defaults for backwards compatibility
@@ -81,14 +103,24 @@ def classify_mood(features: IntensityFeatures) -> str:
     if energy < _ENERGY_MELANCHOLIC_THRESHOLD and vocal_presence > _VOCAL_MELANCHOLIC_THRESHOLD:
         return "Melancholic"
 
-    # Priority 4: Aggressive - high percussiveness, high onset strength
+    # Priority 4: Aggressive - very high percussiveness, high onset strength
+    # (before Energetic to ensure Aggressive takes precedence for harsh electronic)
     if (
         percussiveness > _PERCUSSIVE_AGGRESSIVE_THRESHOLD
         and onset_strength > _ONSET_AGGRESSIVE_THRESHOLD
     ):
         return "Aggressive"
 
-    # Priority 5: Dreamy - low percussiveness, high brightness
+    # Priority 5: Energetic - high RMS + high percussiveness (techno/electronic)
+    # This catches high-energy electronic music that falls through to Ethereal
+    if (
+        energy > _RMS_ENERGETIC_THRESHOLD
+        and percussiveness > _PERCUSSIVE_ENERGETIC_THRESHOLD
+        and brightness > _BRIGHTNESS_ENERGETIC_THRESHOLD
+    ):
+        return "Energetic"
+
+    # Priority 6: Dreamy - low percussiveness, high brightness
     if percussiveness < _PERCUSSIVE_DREAMY_THRESHOLD and brightness > _BRIGHTNESS_DREAMY_THRESHOLD:
         return "Dreamy"
 

--- a/tests/unit/test_mood_classifier.py
+++ b/tests/unit/test_mood_classifier.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from playchitect.core.intensity_analyzer import IntensityFeatures
 from playchitect.core.mood_classifier import classify_mood
 
@@ -234,3 +236,107 @@ class TestMoodClassifier:
         for expected_mood, features in test_cases:
             actual_mood = classify_mood(features)
             assert actual_mood == expected_mood, f"Expected {expected_mood}, got {actual_mood}"
+
+
+class TestElectronicMusicMoodClassification:
+    """Tests for electronic music mood classification (techno/house/dnb).
+
+    These tests verify the fix for BUG-06 where electronic/techno tracks
+    were incorrectly classified as 'Ethereal' due to miscalibrated thresholds.
+    """
+
+    @pytest.mark.parametrize(
+        "rms_energy,brightness,percussiveness,onset_strength,expected_mood",
+        [
+            pytest.param(
+                0.15,
+                0.6,
+                0.6,
+                0.4,
+                "Energetic",
+                id="techno-high-energy",
+            ),
+            pytest.param(
+                0.12,
+                0.55,
+                0.51,
+                0.3,
+                "Energetic",
+                id="house-typical",
+            ),
+            pytest.param(
+                0.4,
+                0.7,
+                0.8,
+                0.7,
+                "Aggressive",
+                id="dnb-aggressive",
+            ),
+            pytest.param(
+                0.2,
+                0.65,
+                0.55,
+                0.35,
+                "Energetic",
+                id="techno-bright",
+            ),
+            pytest.param(
+                0.18,
+                0.7,
+                0.52,
+                0.3,
+                "Energetic",
+                id="house-bright",
+            ),
+        ],
+    )
+    def test_electronic_music_not_ethereal(
+        self,
+        rms_energy: float,
+        brightness: float,
+        percussiveness: float,
+        onset_strength: float,
+        expected_mood: str,
+    ) -> None:
+        """High RMS + high percussiveness + high brightness should NOT be Ethereal."""
+        features = IntensityFeatures(
+            file_path=Path("test.mp3"),
+            file_hash="abc123",
+            rms_energy=rms_energy,
+            brightness=brightness,
+            sub_bass_energy=0.3,
+            kick_energy=0.4,
+            bass_harmonics=0.3,
+            percussiveness=percussiveness,
+            onset_strength=onset_strength,
+            camelot_key="8B",
+            key_index=0.0,
+            dynamic_range=0.4,
+            vocal_presence=0.1,
+        )
+        mood = classify_mood(features)
+        assert mood != "Ethereal", (
+            f"Electronic music with rms={rms_energy}, brightness={brightness}, "
+            f"percussiveness={percussiveness} should not be Ethereal"
+        )
+        assert mood == expected_mood, f"Expected {expected_mood}, got {mood}"
+
+    def test_acceptance_criteria_high_rms_percussive_bright_not_ethereal(
+        self,
+    ) -> None:
+        """Acceptance criteria: high RMS (>0.1) + high percussiveness (>0.5) + high brightness."""
+        features = IntensityFeatures(
+            file_path=Path("test.mp3"),
+            file_hash="abc123",
+            rms_energy=0.15,
+            brightness=0.6,
+            sub_bass_energy=0.3,
+            kick_energy=0.4,
+            bass_harmonics=0.3,
+            percussiveness=0.6,
+            onset_strength=0.4,
+            camelot_key="8B",
+            key_index=0.0,
+        )
+        mood = classify_mood(features)
+        assert mood in ("Energetic", "Aggressive"), f"Expected Energetic or Aggressive, got {mood}"


### PR DESCRIPTION
## [BUG-06] fix_mood_classifier_all_ethereal_for_electronic_music

**Epic:** GUI Stability
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
The rule-based mood classifier in playchitect/core/mood_classifier.py returns 'Ethereal' (the catch-all default at line ~110) for nearly all electronic/techno tracks because the threshold rules for Energetic, Aggressive, Hypnotic etc. are not calibrated for this genre. Review and recalibrate the decision-tree thresholds using typical electronic music feature ranges. In particular: high RMS + high spectral centroid + high percussiveness should resolve to 'Energetic' or 'Aggressive', not fall through to 'Ethereal'. Add unit tests that assert specific mood labels for synthetic feature vectors representative of techno/house/dnb.

### Acceptance Criteria
A synthetic IntensityFeatures with high RMS (>0.1), high percussiveness (>0.5), and high spectral centroid classifies as 'Energetic' or 'Aggressive', not 'Ethereal'. Existing mood classifier tests still pass. uv run pytest tests/ -v passes.

---
*Ralph Loop — multi-agent AI pair programming*