### PR TITLE
[GUI-01a] rename_cluster_to_playlist_in_views_and_widgets

### DIFF
--- a/playchitect/gui/views/export_view.py
+++ b/playchitect/gui/views/export_view.py
@@ -56,7 +56,7 @@ class ExportView(Gtk.Box):
 
     Features:
     - Format selection (M3U, CUE, and future DJ software formats)
-    - Playlist/cluster selection (all or selected only)
+    - Playlist selection (all or selected only)
     - Destination directory selection with persistence
     - Export action with background threading
     - Export status display
@@ -170,7 +170,7 @@ class ExportView(Gtk.Box):
 
         playlists_box.append(radio_box)
 
-        # Cluster dropdown (insensitive unless 'Selected only' is active)
+        # Playlist dropdown (insensitive unless 'Selected only' is active)
         dropdown_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         dropdown_box.set_margin_start(8)
         dropdown_box.set_margin_top(4)
@@ -235,7 +235,7 @@ class ExportView(Gtk.Box):
         # Sync with Mixxx button (enabled - requires config)
         self._sync_button = Gtk.Button(label="↺ Sync with Mixxx")
         self._sync_button.set_sensitive(True)
-        self._sync_button.set_tooltip_text("Sync clusters as crates to Mixxx database")
+        self._sync_button.set_tooltip_text("Sync playlists as crates to Mixxx database")
         self._sync_button.connect("clicked", self._on_sync_mixxx_clicked)
         action_box.append(self._sync_button)
 

--- a/playchitect/gui/views/playlists_view.py
+++ b/playchitect/gui/views/playlists_view.py
@@ -327,8 +327,8 @@ class PlaylistsView(Gtk.Box):
         self._spinner.set_visible(False)
         self._action_bar.pack_end(self._spinner)
 
-        # Right: Cluster count label
-        self._count_label = Gtk.Label(label="0 clusters")
+        # Right: Playlist count label
+        self._count_label = Gtk.Label(label="0 playlists")
         self._count_label.set_margin_end(12)
         self._count_label.add_css_class("caption")
         self._count_label.add_css_class("dim-label")
@@ -374,7 +374,7 @@ class PlaylistsView(Gtk.Box):
 
         # Placeholder for empty state
         self._cluster_placeholder = Gtk.Label(
-            label="No clusters yet.\nClick 'Generate Playlists' to analyze tracks."
+            label="No playlists yet.\nClick 'Generate Playlists' to analyze tracks."
         )
         self._cluster_placeholder.set_justify(Gtk.Justification.CENTER)
         self._cluster_placeholder.add_css_class("dim-label")
@@ -647,7 +647,7 @@ class PlaylistsView(Gtk.Box):
 
         # Update count label
         count = len(self._cluster_stats)
-        noun = "cluster" if count == 1 else "clusters"
+        noun = "playlist" if count == 1 else "playlists"
         self._count_label.set_text(f"{count} {noun}")
 
         # Emit signal with clusters for other views (Export, Set Builder)
@@ -809,7 +809,7 @@ class PlaylistsView(Gtk.Box):
 
         # Update count
         count = len(self._cluster_stats)
-        noun = "cluster" if count == 1 else "clusters"
+        noun = "playlist" if count == 1 else "playlists"
         self._count_label.set_text(f"{count} {noun}")
 
     def get_selected_cluster_id(self) -> int | str | None:
@@ -827,7 +827,7 @@ class PlaylistsView(Gtk.Box):
         self._selected_cluster_id = None
         self._refresh_cluster_sidebar()
         self._track_list.clear()
-        self._count_label.set_text("0 clusters")
+        self._count_label.set_text("0 playlists")
         self._update_stats_display(None)
 
     # ── Issue #37: Harmonic Mixing Controls ────────────────────────────────────

--- a/playchitect/gui/views/set_builder_view.py
+++ b/playchitect/gui/views/set_builder_view.py
@@ -715,7 +715,7 @@ class SetBuilderView(Gtk.Box):
         """Load tracks for the selected block into the browser."""
         self._browser_store.remove_all()
 
-        # Get tracks from clusters assigned to this block
+        # Get tracks from playlists assigned to this block
         track_paths: list[Path] = []
         for cluster_id in block.cluster_ids:
             for cluster in self._clusters:

--- a/playchitect/gui/widgets/cluster_stats.py
+++ b/playchitect/gui/widgets/cluster_stats.py
@@ -25,7 +25,7 @@ _BAR_WIDTH: int = 10
 
 @dataclass(frozen=True)
 class ClusterStats:
-    """Computed display values for a single cluster.
+    """Computed display values for a single playlist.
 
     All string properties are ready to embed directly into UI labels.
     """
@@ -101,7 +101,7 @@ class ClusterStats:
 
     @property
     def intensity_label(self) -> str:
-        """Categorical label for the cluster's intensity level."""
+        """Categorical label for the playlist's intensity level."""
         if self.intensity_mean >= _VERY_HIGH_THRESHOLD:
             return "Very High"
         if self.intensity_mean >= _HIGH_THRESHOLD:
@@ -153,13 +153,13 @@ class ClusterStats:
 
     @property
     def cluster_label(self) -> str:
-        """Short display label, e.g. ``'Cluster 1'`` or ``'1a'`` for split clusters."""
-        return f"Cluster {self.cluster_id}"
+        """Short display label, e.g. ``'Playlist 1'`` or ``'1a'`` for split playlists."""
+        return f"Playlist {self.cluster_id}"
 
     def bpm_range_fraction(self, global_min: float, global_max: float) -> float:
-        """Position of this cluster's mean BPM within the global BPM range [0, 1].
+        """Position of this playlist's mean BPM within the global BPM range [0, 1].
 
-        Used for rendering a relative position indicator across all cluster cards.
+        Used for rendering a relative position indicator across all playlist cards.
         Returns 0.0 if ``global_min == global_max``.
         """
         span = global_max - global_min
@@ -178,7 +178,7 @@ class ClusterStats:
 
     @staticmethod
     def global_bpm_range(stats: list[ClusterStats]) -> tuple[float, float]:
-        """Return ``(global_min_bpm, global_max_bpm)`` across all cluster stats.
+        """Return ``(global_min_bpm, global_max_bpm)`` across all playlist stats.
 
         Useful for normalising BPM bars so all cards share the same scale.
         Returns ``(0.0, 200.0)`` when the list is empty.

--- a/playchitect/gui/widgets/cluster_view.py
+++ b/playchitect/gui/widgets/cluster_view.py
@@ -103,7 +103,7 @@ class ClusterCard(Gtk.Frame):
         rename_btn = Gtk.Button()
         rename_btn.set_icon_name("document-edit-symbolic")
         rename_btn.add_css_class("flat")
-        rename_btn.set_tooltip_text("Rename cluster")
+        rename_btn.set_tooltip_text("Rename playlist")
         rename_btn.connect("clicked", self._on_rename_clicked)
 
         header.append(self._title_label)
@@ -288,7 +288,7 @@ class ClusterViewPanel(Gtk.Box):
         header.set_margin_top(6)
         header.set_margin_bottom(4)
 
-        self._header_label = Gtk.Label(label="Clusters")
+        self._header_label = Gtk.Label(label="Playlists")
         self._header_label.set_xalign(0.0)
         self._header_label.add_css_class("title-4")
         self._header_label.set_hexpand(True)
@@ -307,7 +307,7 @@ class ClusterViewPanel(Gtk.Box):
         self.append(scroll)
 
         # ── Empty state placeholder ───────────────────────────────────────────
-        self._placeholder = Gtk.Label(label="No clusters yet.\nRun analysis to group tracks.")
+        self._placeholder = Gtk.Label(label="No playlists yet.\nRun analysis to group tracks.")
         self._placeholder.set_justify(Gtk.Justification.CENTER)
         self._placeholder.add_css_class("dim-label")
         self._placeholder.set_vexpand(True)
@@ -325,7 +325,7 @@ class ClusterViewPanel(Gtk.Box):
 
         if not stats_list:
             self._placeholder.set_visible(True)
-            self._header_label.set_text("Clusters")
+            self._header_label.set_text("Playlists")
             return
 
         self._placeholder.set_visible(False)
@@ -334,7 +334,7 @@ class ClusterViewPanel(Gtk.Box):
         for stats in stats_list:
             self._add_card(stats, global_min, global_max)
 
-        noun = "cluster" if len(stats_list) == 1 else "clusters"
+        noun = "playlist" if len(stats_list) == 1 else "playlists"
         self._header_label.set_text(f"{len(stats_list)} {noun}")
 
     def update_cluster(self, stats: ClusterStats) -> None:

--- a/tests/gui/test_cluster_view.py
+++ b/tests/gui/test_cluster_view.py
@@ -172,7 +172,7 @@ class TestClusterViewPanelLoadClusters:
         panel = _make_panel()
         panel.load_clusters([])
 
-        panel._header_label.set_text.assert_called_with("Clusters")
+        panel._header_label.set_text.assert_called_with("Playlists")
 
     def test_load_multiple_hides_placeholder(self):
         panel = _make_panel()
@@ -185,13 +185,13 @@ class TestClusterViewPanelLoadClusters:
         panel = _make_panel()
         with patch.object(panel, "_add_card"):
             panel.load_clusters([_make_stats(1)])
-        panel._header_label.set_text.assert_called_with("1 cluster")
+        panel._header_label.set_text.assert_called_with("1 playlist")
 
     def test_load_plural_header(self):
         panel = _make_panel()
         with patch.object(panel, "_add_card"):
             panel.load_clusters([_make_stats(1), _make_stats(2), _make_stats(3)])
-        panel._header_label.set_text.assert_called_with("3 clusters")
+        panel._header_label.set_text.assert_called_with("3 playlists")
 
     def test_existing_cards_cleared_before_load(self):
         panel = _make_panel()

--- a/tests/gui/test_playlists_view.py
+++ b/tests/gui/test_playlists_view.py
@@ -179,7 +179,7 @@ class TestPlaylistsViewPublicAPI:
         assert view._cluster_stats == []
         assert view._selected_cluster_id is None
         view._track_list.clear.assert_called_once()
-        view._count_label.set_text.assert_called_with("0 clusters")
+        view._count_label.set_text.assert_called_with("0 playlists")
 
 
 # ── TestPlaylistsViewStatsDisplay ───────────────────────────────────────────
@@ -275,7 +275,7 @@ class TestPlaylistsViewClusterLoading:
         assert len(view._clusters) == 1
         assert len(view._cluster_stats) == 1
         view._refresh_cluster_sidebar.assert_called_once()  # ty: ignore[unresolved-attribute]
-        view._count_label.set_text.assert_called_once_with("1 cluster")
+        view._count_label.set_text.assert_called_once_with("1 playlist")
 
     def test_load_clusters_plural_label(self):
         """Test that cluster count label uses plural form."""
@@ -300,7 +300,7 @@ class TestPlaylistsViewClusterLoading:
 
         view.load_clusters(clusters)
 
-        view._count_label.set_text.assert_called_once_with("3 clusters")
+        view._count_label.set_text.assert_called_once_with("3 playlists")
 
 
 # ── TestPlaylistsViewInstantiation ──────────────────────────────────────────

--- a/tests/unit/test_cluster_stats.py
+++ b/tests/unit/test_cluster_stats.py
@@ -330,7 +330,7 @@ class TestClusterLabel:
             hardness_mean=0.5,
             total_duration=3600.0,
         )
-        assert stats.cluster_label == "Cluster 2"
+        assert stats.cluster_label == "Playlist 2"
 
     def test_string_id(self):
         stats = ClusterStats(
@@ -343,7 +343,7 @@ class TestClusterLabel:
             hardness_mean=0.3,
             total_duration=1800.0,
         )
-        assert stats.cluster_label == "Cluster 1a"
+        assert stats.cluster_label == "Playlist 1a"
 
 
 # ── TestTopFeatures ───────────────────────────────────────────────────────────
@@ -552,7 +552,7 @@ class TestStr:
             total_duration=5400.0,
         )
         result = str(stats)
-        assert "Cluster 3" in result
+        assert "Playlist 3" in result
         assert "120–128 BPM" in result
         assert "15 tracks" in result
         assert "1h 30m" in result


### PR DESCRIPTION
## [GUI-01a] rename_cluster_to_playlist_in_views_and_widgets

**Epic:** GUI UX
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Rename all user-facing occurrences of 'Cluster'/'cluster' to 'Playlist'/'playlist' in the GUI view and widget files only. This does NOT require renaming internal Python class names like ClusterResult — only strings visible to the user: labels, button text, toast notifications, dropdown options, log messages shown in the UI. Files in scope: playlists_view.py, export_view.py, set_builder_view.py, cluster_view.py, cluster_stats.py. Do NOT touch main_window.py or numbering in this task (covered by GUI-01b).

### Acceptance Criteria
No user-visible string in playlists_view.py, export_view.py, set_builder_view.py, cluster_view.py, or cluster_stats.py contains the word 'Cluster' or 'cluster'. uv run pytest tests/ -v passes.

---
*Ralph Loop — multi-agent AI pair programming*