### PR TITLE
[GUI-05] add_tooltips_to_all_major_controls

### DIFF
--- a/playchitect/gui/views/export_view.py
+++ b/playchitect/gui/views/export_view.py
@@ -213,6 +213,7 @@ class ExportView(Gtk.Box):
         entry_box.append(self._destination_entry)
 
         self._browse_button = Gtk.Button(label="Browse…")
+        self._browse_button.set_tooltip_text("Choose where to save exported playlists")
         self._browse_button.connect("clicked", self._on_browse_clicked)
         entry_box.append(self._browse_button)
 
@@ -229,6 +230,9 @@ class ExportView(Gtk.Box):
         # Export button (suggested-action style)
         self._export_button = Gtk.Button(label="Export")
         self._export_button.add_css_class("suggested-action")
+        self._export_button.set_tooltip_text(
+            "Export playlists to the selected formats and destination"
+        )
         self._export_button.connect("clicked", self._on_export_clicked)
         action_box.append(self._export_button)
 

--- a/playchitect/gui/views/playlists_view.py
+++ b/playchitect/gui/views/playlists_view.py
@@ -176,6 +176,7 @@ class PlaylistsView(Gtk.Box):
         # Left: Generate Playlists button (primary style)
         self._generate_btn = Gtk.Button(label="Generate Playlists")
         self._generate_btn.add_css_class("suggested-action")
+        self._generate_btn.set_tooltip_text("Analyze and cluster your tracks into playlists")
         self._generate_btn.connect("clicked", self._on_generate_clicked)
         self._action_bar.pack_start(self._generate_btn)
 
@@ -196,6 +197,7 @@ class PlaylistsView(Gtk.Box):
         self._size_spin.set_snap_to_ticks(True)
         self._size_spin.set_numeric(True)
         self._size_spin.set_width_chars(4)
+        self._size_spin.set_tooltip_text("Target size for each playlist")
         size_box.append(self._size_spin)
         controls_box.append(size_box)
 
@@ -203,6 +205,9 @@ class PlaylistsView(Gtk.Box):
         unit_model = Gtk.StringList.new(["tracks", "minutes"])
         self._unit_dropdown = Gtk.DropDown(model=unit_model)
         self._unit_dropdown.set_selected(0)  # Default to "tracks"
+        self._unit_dropdown.set_tooltip_text(
+            "Choose whether to target number of tracks or total duration"
+        )
         self._unit_dropdown.connect("notify::selected", self._on_unit_changed)
         controls_box.append(self._unit_dropdown)
 
@@ -218,7 +223,7 @@ class PlaylistsView(Gtk.Box):
         self._playlists_spin.set_snap_to_ticks(True)
         self._playlists_spin.set_numeric(True)
         self._playlists_spin.set_width_chars(3)
-        self._playlists_spin.set_tooltip_text("0 = auto (elbow/silhouette)")
+        self._playlists_spin.set_tooltip_text("Number of playlists to create (0 = auto-detect)")
         playlists_box.append(self._playlists_spin)
         controls_box.append(playlists_box)
 
@@ -242,7 +247,9 @@ class PlaylistsView(Gtk.Box):
             model=Gtk.StringList.new(["Strict", "Loose", "Random"])
         )
         self._harmonic_mode_dropdown.set_selected(0)  # Default to "Strict"
-        self._harmonic_mode_dropdown.set_tooltip_text("Harmonic matching mode")
+        self._harmonic_mode_dropdown.set_tooltip_text(
+            "How strictly to match harmonic keys between tracks"
+        )
         self._harmonic_mode_dropdown.set_sensitive(False)  # Disabled until switch is on
         harmonic_box.append(self._harmonic_mode_dropdown)
 
@@ -377,7 +384,9 @@ class PlaylistsView(Gtk.Box):
         fresh_box.append(fresh_label)
 
         self._fresh_switch = Gtk.Switch()
-        self._fresh_switch.set_tooltip_text("Prioritize tracks not recently played")
+        self._fresh_switch.set_tooltip_text(
+            "Prioritize tracks you haven't played recently when building playlists"
+        )
         self._fresh_switch.connect("notify::active", self._on_fresh_switch_toggled)
         fresh_box.append(self._fresh_switch)
 

--- a/playchitect/gui/views/set_builder_view.py
+++ b/playchitect/gui/views/set_builder_view.py
@@ -533,14 +533,14 @@ class SetBuilderView(Gtk.Box):
         # Auto-fill button
         self._auto_fill_button = Gtk.Button(label="Auto-fill")
         self._auto_fill_button.set_tooltip_text(
-            "Automatically add compatible tracks from the last track"
+            "Automatically add compatible tracks from the last track in your set"
         )
         self._auto_fill_button.connect("clicked", self._on_auto_fill_clicked)
         box.append(self._auto_fill_button)
 
         # Export Set button
         self._export_button = Gtk.Button(label="Export Set")
-        self._export_button.set_tooltip_text("Export the current set as an M3U playlist")
+        self._export_button.set_tooltip_text("Save your current set as an M3U playlist file")
         self._export_button.connect("clicked", self._on_export_clicked)
         box.append(self._export_button)
 

--- a/playchitect/gui/widgets/cluster_view.py
+++ b/playchitect/gui/widgets/cluster_view.py
@@ -204,6 +204,7 @@ class ClusterCard(Gtk.Frame):
         view_btn.add_css_class("pill")
         view_btn.set_halign(Gtk.Align.END)
         view_btn.set_hexpand(True)
+        view_btn.set_tooltip_text("View and edit tracks in this playlist")
         view_btn.connect("clicked", self._on_view_tracks_clicked)
         btn_row.append(view_btn)
         outer.append(btn_row)

--- a/playchitect/gui/widgets/energy_arc_widget.py
+++ b/playchitect/gui/widgets/energy_arc_widget.py
@@ -55,6 +55,7 @@ class EnergyArcWidget(Gtk.DrawingArea):
         self._clusters: list[tuple[str, float]] = []
         self.set_size_request(-1, _MIN_HEIGHT)
         self.set_draw_func(self._on_draw)
+        self.set_tooltip_text("Energy arc showing intensity flow across playlists")
 
     def update_clusters(self, clusters: list[ClusterResult]) -> None:
         """Update the widget with new cluster data.

--- a/tests/gui/test_tooltips_gui_issue5.py
+++ b/tests/gui/test_tooltips_gui_issue5.py
@@ -1,0 +1,281 @@
+"""Tests for tooltip presence on major GUI controls - GUI-05.
+
+Validates that all major controls have descriptive tooltips that explain
+their purpose in plain language appropriate for a DJ user.
+
+These tests verify that set_tooltip_text calls exist in the source code
+by inspecting the actual implementation.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+class SourceTooltipVerifier:
+    """Helper class to verify tooltips are set in source code."""
+
+    @staticmethod
+    def file_has_tooltip_call(file_path: Path, widget_name: str) -> bool:
+        """Check if a file contains set_tooltip_text call for a widget."""
+        try:
+            content = file_path.read_text()
+            # Look for the pattern: widget_name.set_tooltip_text(
+            # This is a simple heuristic - we're looking for the actual tooltip text being set
+            return (
+                f"{widget_name}.set_tooltip_text" in content
+                or f"{widget_name}.set_tooltip_text" in content.replace(" ", "")
+            )
+        except Exception:
+            return False
+
+
+class TestPlaylistsViewTooltips:
+    """Tests for tooltips on PlaylistsView controls."""
+
+    def test_generate_button_tooltip_in_source(self) -> None:
+        """Generate Playlists button should have a tooltip set in source."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "views"
+            / "playlists_view.py"
+        )
+        content = file_path.read_text()
+        # Check that tooltip is set on generate button
+        assert "_generate_btn.set_tooltip_text" in content, (
+            "Generate button should have tooltip set"
+        )
+
+    def test_size_spin_tooltip_in_source(self) -> None:
+        """Size spin button should have a tooltip set in source."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "views"
+            / "playlists_view.py"
+        )
+        content = file_path.read_text()
+        assert "_size_spin.set_tooltip_text" in content, "Size spin should have tooltip set"
+
+    def test_unit_dropdown_tooltip_in_source(self) -> None:
+        """Unit dropdown should have a tooltip set in source."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "views"
+            / "playlists_view.py"
+        )
+        content = file_path.read_text()
+        assert "_unit_dropdown.set_tooltip_text" in content, "Unit dropdown should have tooltip set"
+
+    def test_playlists_spin_tooltip_in_source(self) -> None:
+        """Playlists spin should have a tooltip set in source."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "views"
+            / "playlists_view.py"
+        )
+        content = file_path.read_text()
+        assert "_playlists_spin.set_tooltip_text" in content, (
+            "Playlists spin should have tooltip set"
+        )
+
+    def test_sequence_dropdown_tooltip_in_source(self) -> None:
+        """Sequence dropdown should have a tooltip set in source."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "views"
+            / "playlists_view.py"
+        )
+        content = file_path.read_text()
+        assert "_sequence_dropdown.set_tooltip_text" in content, (
+            "Sequence dropdown should have tooltip set"
+        )
+
+    def test_intro_dropdown_tooltip_in_source(self) -> None:
+        """Intro dropdown should have a tooltip set in source."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "views"
+            / "playlists_view.py"
+        )
+        content = file_path.read_text()
+        assert "_intro_dropdown.set_tooltip_text" in content, (
+            "Intro dropdown should have tooltip set"
+        )
+
+    def test_fresh_switch_tooltip_in_source(self) -> None:
+        """Fresh toggle switch should have a tooltip set in source."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "views"
+            / "playlists_view.py"
+        )
+        content = file_path.read_text()
+        assert "_fresh_switch.set_tooltip_text" in content, "Fresh switch should have tooltip set"
+
+
+class TestExportViewTooltips:
+    """Tests for tooltips on ExportView controls."""
+
+    def test_export_button_tooltip_in_source(self) -> None:
+        """Export button should have a tooltip set in source."""
+        file_path = (
+            Path(__file__).parent.parent.parent / "playchitect" / "gui" / "views" / "export_view.py"
+        )
+        content = file_path.read_text()
+        assert "_export_button.set_tooltip_text" in content, "Export button should have tooltip set"
+
+    def test_browse_button_tooltip_in_source(self) -> None:
+        """Browse button should have a tooltip set in source."""
+        file_path = (
+            Path(__file__).parent.parent.parent / "playchitect" / "gui" / "views" / "export_view.py"
+        )
+        content = file_path.read_text()
+        assert "_browse_button.set_tooltip_text" in content, "Browse button should have tooltip set"
+
+
+class TestSetBuilderViewTooltips:
+    """Tests for tooltips on SetBuilderView controls."""
+
+    def test_auto_fill_button_tooltip_in_source(self) -> None:
+        """Auto-fill button should have a tooltip set in source."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "views"
+            / "set_builder_view.py"
+        )
+        content = file_path.read_text()
+        assert "_auto_fill_button.set_tooltip_text" in content, (
+            "Auto-fill button should have tooltip set"
+        )
+
+    def test_export_button_tooltip_in_source(self) -> None:
+        """Export Set button should have a tooltip set in source."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "views"
+            / "set_builder_view.py"
+        )
+        content = file_path.read_text()
+        # The export button in set_builder_view is named _export_button
+        assert "_export_button.set_tooltip_text" in content, (
+            "Export Set button should have tooltip set"
+        )
+
+
+class TestEnergyArcWidgetTooltip:
+    """Tests for tooltip on EnergyArcWidget."""
+
+    def test_energy_arc_tooltip_in_source(self) -> None:
+        """Energy arc widget should have a tooltip set in source."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "widgets"
+            / "energy_arc_widget.py"
+        )
+        content = file_path.read_text()
+        assert "set_tooltip_text" in content, "Energy arc widget should have tooltip set"
+
+
+class TestClusterViewTooltip:
+    """Tests for tooltip on ClusterCard View Tracks button."""
+
+    def test_view_tracks_button_tooltip_in_source(self) -> None:
+        """View Tracks button should have a tooltip set in source."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "widgets"
+            / "cluster_view.py"
+        )
+        content = file_path.read_text()
+        assert "view_btn.set_tooltip_text" in content, "View Tracks button should have tooltip set"
+
+
+class TestTooltipContentQuality:
+    """Tests that tooltips contain meaningful content (not empty)."""
+
+    def test_playlists_view_tooltips_not_empty(self) -> None:
+        """Verify tooltips in playlists_view.py have non-empty text."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "views"
+            / "playlists_view.py"
+        )
+        content = file_path.read_text()
+        # Verify that set_tooltip_text is called with meaningful strings
+        # by checking it has multiple calls with substantial content
+        tooltip_calls = content.count("set_tooltip_text(")
+        assert tooltip_calls >= 6, f"Expected at least 6 tooltip calls, found {tooltip_calls}"
+
+    def test_export_view_tooltips_not_empty(self) -> None:
+        """Verify tooltips in export_view.py have non-empty text."""
+        file_path = (
+            Path(__file__).parent.parent.parent / "playchitect" / "gui" / "views" / "export_view.py"
+        )
+        content = file_path.read_text()
+        tooltip_calls = content.count("set_tooltip_text(")
+        assert tooltip_calls >= 2, f"Expected at least 2 tooltip calls, found {tooltip_calls}"
+
+    def test_set_builder_view_tooltips_not_empty(self) -> None:
+        """Verify tooltips in set_builder_view.py have non-empty text."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "views"
+            / "set_builder_view.py"
+        )
+        content = file_path.read_text()
+        tooltip_calls = content.count("set_tooltip_text(")
+        assert tooltip_calls >= 2, f"Expected at least 2 tooltip calls, found {tooltip_calls}"
+
+    def test_energy_arc_widget_tooltips_not_empty(self) -> None:
+        """Verify tooltips in energy_arc_widget.py have non-empty text."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "widgets"
+            / "energy_arc_widget.py"
+        )
+        content = file_path.read_text()
+        assert "set_tooltip_text" in content, "Energy arc should have tooltip"
+
+    def test_cluster_view_tooltips_not_empty(self) -> None:
+        """Verify tooltips in cluster_view.py have non-empty text."""
+        file_path = (
+            Path(__file__).parent.parent.parent
+            / "playchitect"
+            / "gui"
+            / "widgets"
+            / "cluster_view.py"
+        )
+        content = file_path.read_text()
+        tooltip_calls = content.count("set_tooltip_text(")
+        assert tooltip_calls >= 2, f"Expected at least 2 tooltip calls, found {tooltip_calls}"

--- a/tests/gui/test_tooltips_gui_issue5.py
+++ b/tests/gui/test_tooltips_gui_issue5.py
@@ -9,10 +9,7 @@ by inspecting the actual implementation.
 
 from __future__ import annotations
 
-import ast
 from pathlib import Path
-
-import pytest
 
 
 class SourceTooltipVerifier:


### PR DESCRIPTION
## [GUI-05] add_tooltips_to_all_major_controls

**Epic:** GUI UX
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Most controls in the app have no tooltip. Add Gtk.Widget.set_tooltip_text() to: all dropdown controls (Sequence, Vocal, Key, Playlists count, Duration target), all buttons (Generate, Autofill, Export, Preview), the cluster/playlist graph widget, the energy arc widget, and the Fresh toggle. Tooltips should explain what the control does in plain language appropriate for a DJ user, not an ML engineer.

### Acceptance Criteria
Hovering over each named control for 1 second shows a non-empty tooltip in plain English. uv run pytest tests/ -v passes.

---
*Ralph Loop — multi-agent AI pair programming*