### PR TITLE
[GUI-06] clarify_vocal_filter_options_in_playlists_view

### DIFF
--- a/playchitect/gui/views/playlists_view.py
+++ b/playchitect/gui/views/playlists_view.py
@@ -324,19 +324,29 @@ class PlaylistsView(Gtk.Box):
         # ToggleButton group for vocal filter
         self._vocal_btn_any = Gtk.ToggleButton(label="Any")
         self._vocal_btn_any.set_active(True)
+        self._vocal_btn_any.set_tooltip_text(
+            "Show all tracks regardless of vocal content. "
+            "Note: Vocal detection has limited accuracy for electronic/techno music."
+        )
         self._vocal_btn_any.connect("toggled", self._on_vocal_filter_changed)
         vocal_box.append(self._vocal_btn_any)
 
-        self._vocal_btn_instrumental = Gtk.ToggleButton(label="Instrumental")
+        self._vocal_btn_instrumental = Gtk.ToggleButton(label="No vocals")
         self._vocal_btn_instrumental.set_group(self._vocal_btn_any)
+        self._vocal_btn_instrumental.set_tooltip_text(
+            "Show tracks with minimal vocal content (vocal_presence < 0.3). "
+            "Note: Vocal detection has limited accuracy for electronic/techno music."
+        )
         self._vocal_btn_instrumental.connect("toggled", self._on_vocal_filter_changed)
-        self._vocal_btn_instrumental.set_tooltip_text("vocal_presence < 0.3")
         vocal_box.append(self._vocal_btn_instrumental)
 
-        self._vocal_btn_vocal = Gtk.ToggleButton(label="Vocal")
+        self._vocal_btn_vocal = Gtk.ToggleButton(label="Vocals")
         self._vocal_btn_vocal.set_group(self._vocal_btn_any)
+        self._vocal_btn_vocal.set_tooltip_text(
+            "Show tracks with significant vocal content (vocal_presence > 0.6). "
+            "Note: Vocal detection has limited accuracy for electronic/techno music."
+        )
         self._vocal_btn_vocal.connect("toggled", self._on_vocal_filter_changed)
-        self._vocal_btn_vocal.set_tooltip_text("vocal_presence > 0.6")
         vocal_box.append(self._vocal_btn_vocal)
 
         self._action_bar.pack_start(vocal_box)

--- a/tests/gui/test_playlists_view.py
+++ b/tests/gui/test_playlists_view.py
@@ -518,6 +518,143 @@ class TestVocalFilterControls:
             # Verify set_active(True) was called
             any_btn.set_active.assert_any_call(True)
 
+    def test_vocal_filter_button_labels_updated(self):
+        """Verify vocal filter buttons have updated labels for clarity."""
+        from unittest.mock import MagicMock, patch
+
+        from playchitect.gui.views.playlists_view import PlaylistsView
+
+        with (
+            patch("playchitect.gui.views.playlists_view.Gtk.Box") as mock_box,
+            patch("playchitect.gui.views.playlists_view.Gtk.ActionBar") as mock_action,
+            patch("playchitect.gui.views.playlists_view.Gtk.Button") as mock_button,
+            patch("playchitect.gui.views.playlists_view.Gtk.ToggleButton") as mock_toggle,
+            patch("playchitect.gui.views.playlists_view.Gtk.SpinButton") as mock_spin,
+            patch("playchitect.gui.views.playlists_view.Gtk.DropDown") as mock_dropdown,
+            patch("playchitect.gui.views.playlists_view.Gtk.StringList") as mock_stringlist,
+            patch("playchitect.gui.views.playlists_view.Gtk.Switch") as mock_switch,
+            patch("playchitect.gui.views.playlists_view.Gtk.Scale") as mock_scale,
+            patch("playchitect.gui.views.playlists_view.TrackListWidget") as mock_tracklist,
+            patch("playchitect.gui.views.playlists_view.Gtk.Spinner") as mock_spinner,
+            patch("playchitect.gui.views.playlists_view.Gtk.Label") as mock_label,
+            patch("playchitect.gui.views.playlists_view.Gtk.Paned") as mock_paned,
+            patch("playchitect.gui.views.playlists_view.Gtk.ListBox") as mock_listbox,
+            patch("playchitect.gui.views.playlists_view.Gtk.ScrolledWindow") as mock_scroll,
+            patch("playchitect.gui.views.playlists_view.Gtk.Separator") as mock_sep,
+            patch("playchitect.gui.views.playlists_view.Gtk.Expander") as mock_expander,
+            patch("playchitect.gui.views.playlists_view.EnergyArcWidget") as mock_energy_arc,
+        ):
+            mock_action.return_value = MagicMock()
+            mock_button.return_value = MagicMock()
+            mock_spinner.return_value = MagicMock()
+            mock_label.return_value = MagicMock()
+            mock_paned.return_value = MagicMock()
+            mock_listbox.return_value = MagicMock()
+            mock_scroll.return_value = MagicMock()
+            mock_sep.return_value = MagicMock()
+            mock_tracklist.return_value = MagicMock()
+            mock_box.return_value = MagicMock()
+            mock_spin.return_value = MagicMock()
+            mock_dropdown.return_value = MagicMock()
+            mock_stringlist.new.return_value = MagicMock()
+            mock_switch.return_value = MagicMock()
+            mock_scale.return_value = MagicMock()
+            mock_energy_arc.return_value = MagicMock()
+            mock_expander.return_value = MagicMock()
+
+            toggle_mocks = []
+
+            def capture_toggle(*args, **kwargs):
+                mock = MagicMock()
+                toggle_mocks.append((args, kwargs, mock))
+                return mock
+
+            mock_toggle.side_effect = capture_toggle
+
+            _ = PlaylistsView()
+
+            labels_found = {kwargs.get("label") for args, kwargs, mock in toggle_mocks}
+            assert "Any" in labels_found, "ToggleButton with label='Any' not found"
+            assert "No vocals" in labels_found, "ToggleButton with label='No vocals' not found"
+            assert "Vocals" in labels_found, "ToggleButton with label='Vocals' not found"
+
+    def test_vocal_filter_buttons_have_tooltips(self):
+        """Verify vocal filter buttons have explanatory tooltips."""
+        from unittest.mock import MagicMock, patch
+
+        from playchitect.gui.views.playlists_view import PlaylistsView
+
+        with (
+            patch("playchitect.gui.views.playlists_view.Gtk.Box") as mock_box,
+            patch("playchitect.gui.views.playlists_view.Gtk.ActionBar") as mock_action,
+            patch("playchitect.gui.views.playlists_view.Gtk.Button") as mock_button,
+            patch("playchitect.gui.views.playlists_view.Gtk.ToggleButton") as mock_toggle,
+            patch("playchitect.gui.views.playlists_view.Gtk.SpinButton") as mock_spin,
+            patch("playchitect.gui.views.playlists_view.Gtk.DropDown") as mock_dropdown,
+            patch("playchitect.gui.views.playlists_view.Gtk.StringList") as mock_stringlist,
+            patch("playchitect.gui.views.playlists_view.Gtk.Switch") as mock_switch,
+            patch("playchitect.gui.views.playlists_view.Gtk.Scale") as mock_scale,
+            patch("playchitect.gui.views.playlists_view.TrackListWidget") as mock_tracklist,
+            patch("playchitect.gui.views.playlists_view.Gtk.Spinner") as mock_spinner,
+            patch("playchitect.gui.views.playlists_view.Gtk.Label") as mock_label,
+            patch("playchitect.gui.views.playlists_view.Gtk.Paned") as mock_paned,
+            patch("playchitect.gui.views.playlists_view.Gtk.ListBox") as mock_listbox,
+            patch("playchitect.gui.views.playlists_view.Gtk.ScrolledWindow") as mock_scroll,
+            patch("playchitect.gui.views.playlists_view.Gtk.Separator") as mock_sep,
+            patch("playchitect.gui.views.playlists_view.Gtk.Expander") as mock_expander,
+            patch("playchitect.gui.views.playlists_view.EnergyArcWidget") as mock_energy_arc,
+        ):
+            mock_action.return_value = MagicMock()
+            mock_button.return_value = MagicMock()
+            mock_spinner.return_value = MagicMock()
+            mock_label.return_value = MagicMock()
+            mock_paned.return_value = MagicMock()
+            mock_listbox.return_value = MagicMock()
+            mock_scroll.return_value = MagicMock()
+            mock_sep.return_value = MagicMock()
+            mock_tracklist.return_value = MagicMock()
+            mock_box.return_value = MagicMock()
+            mock_spin.return_value = MagicMock()
+            mock_dropdown.return_value = MagicMock()
+            mock_stringlist.new.return_value = MagicMock()
+            mock_switch.return_value = MagicMock()
+            mock_scale.return_value = MagicMock()
+            mock_energy_arc.return_value = MagicMock()
+            mock_expander.return_value = MagicMock()
+
+            toggle_mocks = []
+
+            def capture_toggle(*args, **kwargs):
+                mock = MagicMock()
+                toggle_mocks.append((args, kwargs, mock))
+                return mock
+
+            mock_toggle.side_effect = capture_toggle
+
+            _ = PlaylistsView()
+
+            any_tooltip = None
+            no_vocals_tooltip = None
+            vocals_tooltip = None
+
+            for args, kwargs, mock in toggle_mocks:
+                if kwargs.get("label") == "Any":
+                    any_tooltip = mock.set_tooltip_text.call_args
+                elif kwargs.get("label") == "No vocals":
+                    no_vocals_tooltip = mock.set_tooltip_text.call_args
+                elif kwargs.get("label") == "Vocals":
+                    vocals_tooltip = mock.set_tooltip_text.call_args
+
+            assert any_tooltip is not None, "Tooltip not set for 'Any' button"
+            assert no_vocals_tooltip is not None, "Tooltip not set for 'No vocals' button"
+            assert vocals_tooltip is not None, "Tooltip not set for 'Vocals' button"
+
+            any_text = any_tooltip[0][0] if any_tooltip else ""
+            assert "limited accuracy" in any_text, (
+                "Tooltip should mention limited accuracy for electronic music"
+            )
+            assert "electronic" in any_text.lower(), "Tooltip should mention electronic music"
+
 
 class TestIntroColumn:
     """Tests for the Intro column in TrackListWidget (TASK-16)."""


### PR DESCRIPTION
## [GUI-06] clarify_vocal_filter_options_in_playlists_view

**Epic:** GUI UX
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
The Playlists view has a 'Vocal' filter with options 'Any', 'Instrumental', 'Vocal'. These options are confusing for users mixing electronic/techno: (1) Add a tooltip explaining each option and how it affects track selection. (2) Rename options to be clearer: 'Any vocals' → 'Any', 'Instrumental only' → 'No vocals', 'Has vocals' → 'Vocals'. (3) If the vocal detection feature is not reliably implemented, add a note in the tooltip that this filter has limited accuracy for electronic music.

### Acceptance Criteria
Vocal filter has a tooltip explaining its function. Option labels are updated to clearer wording. uv run pytest tests/ -v passes.

---
*Ralph Loop — multi-agent AI pair programming*