### PR TITLE
[GUI-07] maximize_window_on_startup

### DIFF
--- a/playchitect/gui/windows/main_window.py
+++ b/playchitect/gui/windows/main_window.py
@@ -50,6 +50,7 @@ class PlaychitectWindow(Adw.ApplicationWindow):
 
         self.set_title("Playchitect")
         self.set_default_size(1000, 700)
+        self.maximize()
 
         # ── Preview service ───────────────────────────────────────────────────
         self._previewer = TrackPreviewer()

--- a/tests/gui/conftest.py
+++ b/tests/gui/conftest.py
@@ -86,6 +86,9 @@ class _FakeGtkBase:
     def set_default_size(self, *_args: object) -> None:
         pass
 
+    def maximize(self) -> None:
+        pass
+
     def pack_start(self, *_args: object) -> None:
         pass
 

--- a/tests/gui/test_gui_layout.py
+++ b/tests/gui/test_gui_layout.py
@@ -187,10 +187,12 @@ class TestWindowInitCalls:
         """Window created with set_title and set_default_size replaced by spies."""
         spy_title = MagicMock()
         spy_size = MagicMock()
+        spy_maximize = MagicMock()
         spy_content = MagicMock()
 
         monkeypatch.setattr(PlaychitectWindow, "set_title", spy_title)
         monkeypatch.setattr(PlaychitectWindow, "set_default_size", spy_size)
+        monkeypatch.setattr(PlaychitectWindow, "maximize", spy_maximize)
         monkeypatch.setattr(PlaychitectWindow, "set_content", spy_content)
         _patch_deps(monkeypatch)
 
@@ -199,6 +201,7 @@ class TestWindowInitCalls:
             "window": w,
             "set_title": spy_title,
             "set_default_size": spy_size,
+            "maximize": spy_maximize,
             "set_content": spy_content,
         }
 
@@ -207,6 +210,9 @@ class TestWindowInitCalls:
 
     def test_set_default_size_called(self, spied_window: dict[str, Any]) -> None:
         spied_window["set_default_size"].assert_called_once()
+
+    def test_maximize_called(self, spied_window: dict[str, Any]) -> None:
+        spied_window["maximize"].assert_called_once()
 
     def test_set_default_size_matches_design_spec(self, spied_window: dict[str, Any]) -> None:
         args = spied_window["set_default_size"].call_args[0]


### PR DESCRIPTION
## [GUI-07] maximize_window_on_startup

**Epic:** GUI
**Coder:** `opencode` | **Reviewer:** `claude`

### Description
Call self.maximize() immediately after self.set_default_size(1000, 700) in PlaychitectWindow.__init__ (playchitect/gui/windows/main_window.py). This makes the app open maximized by default, matching the behaviour of GNOME Music, Nautilus, and other data-heavy GNOME apps. The window must remain user-resizable and must restore correctly if the user un-maximizes it.

### Acceptance Criteria
App opens maximized on first launch. Un-maximizing leaves a 1000x700 fallback size. uv run pytest tests/ -v passes.

---
*Ralph Loop — multi-agent AI pair programming*