### PR TITLE
[GUI-10] library_view_tag_chips_and_storage_stats

### DIFF
--- a/playchitect/gui/style.css
+++ b/playchitect/gui/style.css
@@ -46,3 +46,12 @@ label.title-2 {
 label {
     color: #C9D1D9;
 }
+
+.tag-chip {
+    background-color: rgba(123, 92, 240, 0.2);
+    border: 1px solid #7B5CF0;
+    border-radius: 12px;
+    padding: 2px 10px;
+    font-size: 0.8em;
+    color: #C9D1D9;
+}

--- a/playchitect/gui/views/library_view.py
+++ b/playchitect/gui/views/library_view.py
@@ -6,6 +6,7 @@ Provides a searchable, filterable track list with format chips and folder scanni
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from pathlib import Path
 from typing import Any
@@ -383,9 +384,23 @@ class LibraryView(Gtk.Box):
         self._update_footer()
 
     def _update_footer(self) -> None:
-        """Update footer label with track count."""
+        """Update footer label with track count and total size."""
         count = self._filter_model.get_n_items()
-        self._footer_label.set_text(f"{count} tracks")
+        total_size = self._calculate_total_size()
+        size_gb = total_size / 1e9
+        self._footer_label.set_text(f"{count} tracks · {size_gb:.1f} GB Total")
+
+    def _calculate_total_size(self) -> float:
+        """Calculate total size of all tracks in the model."""
+        total = 0.0
+        for i in range(self._filter_model.get_n_items()):
+            item = self._filter_model.get_item(i)
+            if item is not None:
+                try:
+                    total += os.path.getsize(item.filepath)
+                except OSError:
+                    pass
+        return total
 
     def _update_preview_chip(self) -> None:
         """Set the preview chip text and style to reflect preview availability."""

--- a/playchitect/gui/widgets/track_preview_panel.py
+++ b/playchitect/gui/widgets/track_preview_panel.py
@@ -41,6 +41,7 @@ try:
 except ImportError:
     GdkPixbuf = None  # type: ignore[misc]
 
+from playchitect.core.metadata_extractor import MetadataExtractor  # noqa: E402
 from playchitect.core.mixxx_sync import MixxxSync  # noqa: E402
 from playchitect.core.structural_analyzer import (  # noqa: E402
     StructuralAnalyzer,
@@ -155,6 +156,7 @@ class TrackPreviewPanel(Gtk.Box):
         self._build_cover_art_section()
         self._build_metadata_section()
         self._build_info_pills_section()
+        self._build_genre_chips_section()
         self._build_tags_section()
         self._build_controls_section()
 
@@ -240,6 +242,54 @@ class TrackPreviewPanel(Gtk.Box):
         pills_box.append(self._format_pill)
 
         self.append(pills_box)
+
+    def _build_genre_chips_section(self) -> None:
+        """Build the genre chips section for metadata genre tags."""
+        genre_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        genre_box.set_margin_top(12)
+
+        label = Gtk.Label()
+        label.set_xalign(0.0)
+        label.add_css_class("caption")
+        label.add_css_class("dim-label")
+        label.set_text("Genre")
+        genre_box.append(label)
+
+        self._genre_flowbox = Gtk.FlowBox()
+        self._genre_flowbox.set_selection_mode(Gtk.SelectionMode.NONE)
+        self._genre_flowbox.set_column_spacing(6)
+        self._genre_flowbox.set_row_spacing(6)
+        self._genre_flowbox.set_homogeneous(False)
+        self._genre_flowbox.set_max_children_per_line(10)
+        genre_box.append(self._genre_flowbox)
+
+        self.append(genre_box)
+
+    def _refresh_genre_chips(self) -> None:
+        """Refresh the genre FlowBox display for current track."""
+        while True:
+            child = self._genre_flowbox.get_first_child()
+            if child is None:
+                break
+            self._genre_flowbox.remove(child)
+
+        if self._current_track is None:
+            return
+
+        extractor = MetadataExtractor()
+        metadata = extractor.extract(Path(self._current_track.filepath))
+
+        if metadata is None or not metadata.genre:
+            return
+
+        chip = self._create_genre_chip(metadata.genre)
+        self._genre_flowbox.append(chip)
+
+    def _create_genre_chip(self, genre: str) -> Gtk.Label:
+        """Create a genre chip label with the tag-chip CSS class."""
+        label = Gtk.Label(label=genre)
+        label.add_css_class("tag-chip")
+        return label
 
     def _build_tags_section(self) -> None:
         """Build the vibe tags section with FlowBox chips and entry."""
@@ -724,6 +774,9 @@ class TrackPreviewPanel(Gtk.Box):
 
         # Refresh tags display
         self._refresh_tags_display()
+
+        # Refresh genre chips from metadata
+        self._refresh_genre_chips()
 
         # Set up GStreamer source
         if self._playbin is not None and Gst is not None:

--- a/tests/gui/test_library_view.py
+++ b/tests/gui/test_library_view.py
@@ -132,6 +132,9 @@ class _FakeFilterModel:
             if self._filter._func(self._model.get_item(i), None)
         )
 
+    def get_item(self, index: int) -> Any:
+        return self._model.get_item(index)
+
 
 class _FakeSortModel:
     """SortListModel stub."""
@@ -620,3 +623,100 @@ class TestSearchAPI:
             library_view.set_search_text("techno")
             assert library_view._search_text == "techno"
             mock_changed.assert_called_once()
+
+
+class TestStorageStats:
+    """Test storage stats calculation and display."""
+
+    @patch("os.path.getsize")
+    def test_calculate_total_size_empty_library(self, mock_getsize) -> None:
+        """_calculate_total_size returns 0 for empty library."""
+        from playchitect.gui.views.library_view import LibraryView
+
+        view = LibraryView.__new__(LibraryView)
+        view._filter_model = MagicMock()
+        view._filter_model.get_n_items.return_value = 0
+        result = view._calculate_total_size()
+        assert result == 0.0
+
+    @patch("os.path.getsize")
+    def test_calculate_total_size_single_track(self, mock_getsize) -> None:
+        """_calculate_total_size sums file sizes."""
+        from playchitect.gui.views.library_view import LibraryView
+
+        mock_getsize.return_value = 50_000_000  # 50 MB
+        view = LibraryView.__new__(LibraryView)
+        view._filter_model = MagicMock()
+        view._filter_model.get_n_items.return_value = 1
+
+        track = MagicMock()
+        track.filepath = "/music/track.flac"
+        view._filter_model.get_item.return_value = track
+
+        result = view._calculate_total_size()
+        assert result == 50_000_000
+
+    @patch("os.path.getsize")
+    def test_calculate_total_size_multiple_tracks(self, mock_getsize) -> None:
+        """_calculate_total_size sums multiple file sizes."""
+        from playchitect.gui.views.library_view import LibraryView
+
+        mock_getsize.side_effect = [30_000_000, 50_000_000, 20_000_000]
+        view = LibraryView.__new__(LibraryView)
+        view._filter_model = MagicMock()
+        view._filter_model.get_n_items.return_value = 3
+
+        tracks = [MagicMock() for _ in range(3)]
+        for i, track in enumerate(tracks):
+            track.filepath = f"/music/track{i}.flac"
+        view._filter_model.get_item.side_effect = tracks
+
+        result = view._calculate_total_size()
+        assert result == 100_000_000
+
+    @patch("os.path.getsize")
+    def test_calculate_total_size_handles_oserror(self, mock_getsize) -> None:
+        """_calculate_total_size ignores OSError from missing files."""
+        from playchitect.gui.views.library_view import LibraryView
+
+        mock_getsize.side_effect = OSError("File not found")
+        view = LibraryView.__new__(LibraryView)
+        view._filter_model = MagicMock()
+        view._filter_model.get_n_items.return_value = 1
+
+        track = MagicMock()
+        track.filepath = "/music/missing.flac"
+        view._filter_model.get_item.return_value = track
+
+        result = view._calculate_total_size()
+        assert result == 0.0
+
+    def test_update_footer_shows_gb_total(self) -> None:
+        """_update_footer shows track count and total size in GB."""
+        from playchitect.gui.views.library_view import LibraryView
+
+        view = LibraryView.__new__(LibraryView)
+        view._filter_model = MagicMock()
+        view._filter_model.get_n_items.return_value = 2147
+
+        view._footer_label = MagicMock()
+
+        with patch.object(view, "_calculate_total_size", return_value=48.2e9):
+            view._update_footer()
+
+        view._footer_label.set_text.assert_called_once_with("2147 tracks · 48.2 GB Total")
+
+    def test_update_footer_zero_tracks(self) -> None:
+        """_update_footer shows 0 tracks when empty."""
+        from playchitect.gui.views.library_view import LibraryView
+
+        view = LibraryView.__new__(LibraryView)
+        view._filter_model = MagicMock()
+        view._filter_model.get_n_items.return_value = 0
+
+        view._footer_label = MagicMock()
+
+        with patch.object(view, "_calculate_total_size", return_value=0.0):
+            view._update_footer()
+
+        view._footer_label.set_text.assert_called_once_with("0 tracks · 0.0 GB Total")

--- a/tests/gui/test_track_preview_panel.py
+++ b/tests/gui/test_track_preview_panel.py
@@ -135,6 +135,10 @@ def panel() -> TrackPreviewPanel:
     p._tag_entry = MagicMock()
     p._completion_model = MagicMock()
 
+    # Mock genre chips
+    p._genre_flowbox = MagicMock()
+    p._genre_flowbox.get_first_child = MagicMock(return_value=None)
+
     # Mock tag store
     p._tag_store = MagicMock()
     p._tag_store.get_tags = MagicMock(return_value=[])
@@ -584,3 +588,110 @@ class TestTagSection:
         panel_with_tags._tag_store.get_tags.assert_called_once()
         call_args = panel_with_tags._tag_store.get_tags.call_args
         assert str(call_args[0][0]) == "/music/test.mp3"
+
+
+class TestGenreChips:
+    """Test genre chips display from metadata."""
+
+    @pytest.fixture()
+    def panel_with_genre(self) -> TrackPreviewPanel:
+        """Return a TrackPreviewPanel with mocked dependencies."""
+        with patch.object(TrackPreviewPanel, "__init__", lambda self: None):
+            panel = TrackPreviewPanel()
+            panel._current_track = None
+            panel._genre_flowbox = MagicMock()
+            panel._genre_flowbox.get_first_child.return_value = None
+            panel._genre_flowbox.remove = MagicMock()
+            panel._genre_flowbox.append = MagicMock()
+            return panel
+
+    def test_refresh_genre_chips_empty_when_no_track(
+        self, panel_with_genre: TrackPreviewPanel
+    ) -> None:
+        """_refresh_genre_chips does nothing when no track is loaded."""
+        panel_with_genre._current_track = None
+        panel_with_genre._refresh_genre_chips()
+        panel_with_genre._genre_flowbox.remove.assert_not_called()
+
+    def test_refresh_genre_chips_clears_existing(self, panel_with_genre: TrackPreviewPanel) -> None:
+        """_refresh_genre_chips clears existing chips before adding new ones."""
+        panel_with_genre._current_track = MagicMock()
+        panel_with_genre._current_track.filepath = "/music/track.flac"
+
+        panel_with_genre._genre_flowbox.get_first_child.side_effect = [
+            MagicMock(),
+            None,
+        ]
+
+        with patch(
+            "playchitect.gui.widgets.track_preview_panel.MetadataExtractor"
+        ) as mock_extractor:
+            mock_meta = MagicMock()
+            mock_meta.genre = "Techno"
+            mock_extractor.return_value.extract.return_value = mock_meta
+
+            panel_with_genre._refresh_genre_chips()
+
+        assert panel_with_genre._genre_flowbox.remove.called
+
+    def test_refresh_genre_chips_adds_genre_label(
+        self, panel_with_genre: TrackPreviewPanel
+    ) -> None:
+        """_refresh_genre_chips adds genre chip when metadata has genre."""
+        panel_with_genre._current_track = MagicMock()
+        panel_with_genre._current_track.filepath = "/music/track.flac"
+        panel_with_genre._genre_flowbox.get_first_child.return_value = None
+
+        with patch(
+            "playchitect.gui.widgets.track_preview_panel.MetadataExtractor"
+        ) as mock_extractor:
+            mock_meta = MagicMock()
+            mock_meta.genre = "Techno"
+            mock_extractor.return_value.extract.return_value = mock_meta
+
+            panel_with_genre._refresh_genre_chips()
+
+        panel_with_genre._genre_flowbox.append.assert_called_once()
+
+    def test_refresh_genre_chips_no_genre_in_metadata(
+        self, panel_with_genre: TrackPreviewPanel
+    ) -> None:
+        """_refresh_genre_chips does nothing when metadata has no genre."""
+        panel_with_genre._current_track = MagicMock()
+        panel_with_genre._current_track.filepath = "/music/track.flac"
+        panel_with_genre._genre_flowbox.get_first_child.return_value = None
+
+        with patch(
+            "playchitect.gui.widgets.track_preview_panel.MetadataExtractor"
+        ) as mock_extractor:
+            mock_meta = MagicMock()
+            mock_meta.genre = None
+            mock_extractor.return_value.extract.return_value = mock_meta
+
+            panel_with_genre._refresh_genre_chips()
+
+        panel_with_genre._genre_flowbox.append.assert_not_called()
+
+    def test_refresh_genre_chips_none_metadata(self, panel_with_genre: TrackPreviewPanel) -> None:
+        """_refresh_genre_chips does nothing when extract returns None."""
+        panel_with_genre._current_track = MagicMock()
+        panel_with_genre._current_track.filepath = "/music/track.flac"
+        panel_with_genre._genre_flowbox.get_first_child.return_value = None
+
+        with patch(
+            "playchitect.gui.widgets.track_preview_panel.MetadataExtractor"
+        ) as mock_extractor:
+            mock_extractor.return_value.extract.return_value = None
+
+            panel_with_genre._refresh_genre_chips()
+
+        panel_with_genre._genre_flowbox.append.assert_not_called()
+
+    def test_create_genre_chip(self, panel_with_genre: TrackPreviewPanel) -> None:
+        """_create_genre_chip creates a label with tag-chip CSS class."""
+        from gi.repository import Gtk
+
+        chip = panel_with_genre._create_genre_chip("Techno")
+
+        assert chip is not None
+        assert isinstance(chip, Gtk.Label)


### PR DESCRIPTION
## [GUI-10] library_view_tag_chips_and_storage_stats

**Epic:** GUI
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Two additions to `playchitect/gui/views/library_view.py` and `playchitect/gui/widgets/track_preview_panel.py`: (1) TAG CHIPS — when a track is selected and the preview panel is open, display the track's vibe/genre tags as pill-shaped chip labels below the audio player controls. Read tag values from the `TrackMetadata` object (the `tags` or `genre` fields already extracted by `metadata_extractor.py`). Render each non-empty tag as a `Gtk.Label` inside a `Gtk.FlowBox` with CSS class `tag-chip`. Add to `style.css`: `.tag-chip { background-color: rgba(123,92,240,0.2); border: 1px solid #7B5CF0; border-radius: 12px; padding: 2px 10px; font-size: 0.8em; color: #C9D1D9; }`. If the track has no tags, show nothing (do not show an empty FlowBox). (2) STORAGE STATS — in the library status bar (bottom of the track list pane, where '2,147 tracks in library' is shown), append the total size of all scanned files formatted as 'X.X GB Total'. Compute this by summing `os.path.getsize(track.filepath)` for all tracks in the model, formatted with `/ 1e9` rounded to 1 decimal place. Update the label whenever the track list model changes.

### Acceptance Criteria
Selecting a tagged track (e.g. one with genre='Techno') shows the tag as a purple pill chip below the player. Tracks with no tags show no chip section. The status bar shows e.g. '2,147 tracks · 48.2 GB Total'. `uv run pytest tests/ -v` passes.

---
*Ralph Loop — multi-agent AI pair programming*