### PR TITLE
[GUI-12] set_builder_block_and_card_colors

### DIFF
--- a/playchitect/gui/style.css
+++ b/playchitect/gui/style.css
@@ -79,3 +79,57 @@ energy-bar > trough {
 energy-bar > trough > fill {
     background-color: #7B5CF0;
 }
+
+/* GUI-12: Energy block card accent colors */
+/* Intro/Warm-up block - blue */
+intro-block,
+.intro-block {
+    border-top: 3px solid #1E6FD9;
+}
+
+/* Build block - purple */
+build-block,
+.build-block {
+    border-top: 3px solid #7B5CF0;
+}
+
+/* Peak block - orange */
+peak-block,
+.peak-block {
+    border-top: 3px solid #E8641A;
+}
+
+/* Outro/Sustain/Wind Down block - green */
+outro-block,
+.outro-block {
+    border-top: 3px solid #1DAF79;
+}
+
+/* Custom block - use default purple */
+custom-block,
+.custom-block {
+    border-top: 3px solid #7B5CF0;
+}
+
+/* Selected state - brighter background */
+intro-block.card-selected,
+.intro-block.card-selected,
+build-block.card-selected,
+.build-block.card-selected,
+peak-block.card-selected,
+.peak-block.card-selected,
+outro-block.card-selected,
+.outro-block.card-selected,
+custom-block.card-selected,
+.custom-block.card-selected {
+    background-color: rgba(30, 111, 217, 0.15);
+}
+
+/* GUI-12: Track card styling */
+track-card,
+.track-card {
+    border-radius: 8px;
+    background-color: #161B22;
+    border: 1px solid #1E2A3A;
+    padding: 6px 10px;
+}

--- a/playchitect/gui/views/set_builder_view.py
+++ b/playchitect/gui/views/set_builder_view.py
@@ -78,6 +78,15 @@ def _format_duration(seconds: float) -> str:
     return f"{minutes}:{secs:02d}"
 
 
+_BLOCK_CSS_CLASS_MAP: dict[str, str] = {
+    "Warm-up": "intro-block",
+    "Build": "build-block",
+    "Peak": "peak-block",
+    "Sustain": "outro-block",
+    "Wind Down": "outro-block",
+}
+
+
 class EnergyBlockCard(Gtk.Frame):
     """Card widget representing an energy block.
 
@@ -96,6 +105,10 @@ class EnergyBlockCard(Gtk.Frame):
         self.set_margin_end(4)
         self.set_margin_top(4)
         self.set_margin_bottom(4)
+
+        # Add block-type CSS class for accent coloring
+        block_css_class = _BLOCK_CSS_CLASS_MAP.get(energy_block.name, "custom-block")
+        self.add_css_class(block_css_class)
 
         # Main container
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
@@ -258,7 +271,7 @@ class TrackCard(Gtk.Frame):
         box.append(transition_box)
 
         self.set_child(box)
-        self.add_css_class("card")
+        self.add_css_class("track-card")
 
     def _draw_transition_dot(
         self,

--- a/tests/gui/test_set_builder_view.py
+++ b/tests/gui/test_set_builder_view.py
@@ -59,6 +59,101 @@ class TestEnergyBlockCard:
         card.set_selected(False)
         assert "card-selected" in removed_classes
 
+    def test_card_has_block_css_class_warmup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that Warm-up block gets intro-block CSS class."""
+        block = EnergyBlock(
+            id="warm-up",
+            name="Warm-up",
+            target_duration_min=60.0,
+            energy_min=0.2,
+            energy_max=0.4,
+            cluster_ids=[1],
+        )
+        added_classes: list[str] = []
+        monkeypatch.setattr(
+            EnergyBlockCard, "add_css_class", lambda self, cls: added_classes.append(cls)
+        )
+        EnergyBlockCard(block)
+        assert "intro-block" in added_classes
+
+    def test_card_has_block_css_class_build(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that Build block gets build-block CSS class."""
+        block = EnergyBlock(
+            id="build",
+            name="Build",
+            target_duration_min=60.0,
+            energy_min=0.4,
+            energy_max=0.6,
+            cluster_ids=[2],
+        )
+        added_classes: list[str] = []
+        monkeypatch.setattr(
+            EnergyBlockCard, "add_css_class", lambda self, cls: added_classes.append(cls)
+        )
+        EnergyBlockCard(block)
+        assert "build-block" in added_classes
+
+    def test_card_has_block_css_class_peak(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that Peak block gets peak-block CSS class."""
+        block = EnergyBlock(
+            id="peak",
+            name="Peak",
+            target_duration_min=60.0,
+            energy_min=0.6,
+            energy_max=0.8,
+            cluster_ids=[3],
+        )
+        added_classes: list[str] = []
+        monkeypatch.setattr(
+            EnergyBlockCard, "add_css_class", lambda self, cls: added_classes.append(cls)
+        )
+        EnergyBlockCard(block)
+        assert "peak-block" in added_classes
+
+    def test_card_has_block_css_class_outro(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that Sustain block gets outro-block CSS class."""
+        block = EnergyBlock(
+            id="sustain",
+            name="Sustain",
+            target_duration_min=60.0,
+            energy_min=0.8,
+            energy_max=0.95,
+            cluster_ids=[4],
+        )
+        added_classes: list[str] = []
+        monkeypatch.setattr(
+            EnergyBlockCard, "add_css_class", lambda self, cls: added_classes.append(cls)
+        )
+        EnergyBlockCard(block)
+        assert "outro-block" in added_classes
+
+    def test_card_has_block_css_class_wind_down(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that Wind Down block gets outro-block CSS class."""
+        block = EnergyBlock(
+            id="wind-down",
+            name="Wind Down",
+            target_duration_min=60.0,
+            energy_min=0.95,
+            energy_max=1.0,
+            cluster_ids=[5],
+        )
+        added_classes: list[str] = []
+        monkeypatch.setattr(
+            EnergyBlockCard, "add_css_class", lambda self, cls: added_classes.append(cls)
+        )
+        EnergyBlockCard(block)
+        assert "outro-block" in added_classes
+
+    def test_card_has_block_css_class_custom(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that Custom block gets custom-block CSS class."""
+        block = create_custom_block("custom-1")
+        added_classes: list[str] = []
+        monkeypatch.setattr(
+            EnergyBlockCard, "add_css_class", lambda self, cls: added_classes.append(cls)
+        )
+        EnergyBlockCard(block)
+        assert "custom-block" in added_classes
+
 
 class TestTrackCard:
     """Tests for TrackCard widget."""
@@ -171,6 +266,28 @@ class TestTrackCard:
 
         card.set_transition_color("red")
         assert card._transition_color == "red"
+
+    def test_track_card_has_track_card_css_class(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that TrackCard gets track-card CSS class for styling."""
+        path = Path("/music/track.mp3")
+        metadata = TrackMetadata(filepath=path, title="Track", bpm=130.0)
+        features = IntensityFeatures(
+            file_path=path,
+            file_hash="hash",
+            rms_energy=0.5,
+            brightness=0.5,
+            sub_bass_energy=0.3,
+            kick_energy=0.6,
+            bass_harmonics=0.4,
+            percussiveness=0.5,
+            onset_strength=0.5,
+            camelot_key="9B",
+            key_index=1.0,
+        )
+        added_classes: list[str] = []
+        monkeypatch.setattr(TrackCard, "add_css_class", lambda self, cls: added_classes.append(cls))
+        TrackCard(sequence=1, metadata=metadata, features=features)
+        assert "track-card" in added_classes
 
 
 class TestSetBuilderView:


### PR DESCRIPTION
## [GUI-12] set_builder_block_and_card_colors

**Epic:** GUI
**Coder:** `opencode` | **Reviewer:** `opencode`

### Description
Two visual improvements to `playchitect/gui/views/set_builder_view.py` per the Stitch design: (1) ENERGY BLOCK CARD COLORS — each `EnergyBlockCard` (or equivalent widget in set_builder_view.py) represents a block type (Intro, Build, Peak, Outro). Apply a distinct accent colour to each by adding a CSS class based on block name: `intro-block` → `#1E6FD9` (blue), `build-block` → `#7B5CF0` (purple), `peak-block` → `#E8641A` (orange), `outro-block` → `#1DAF79` (green). Add these rules to `style.css`. The card border or top-accent strip (3px top border) should use the block colour. The active/selected block card should have a brighter version of its colour as background. (2) TRACK CARD STYLING — each track card widget in the Set Builder timeline (showing sequence number, title, BPM, energy mini-bar, transition dot) should be styled as a card: `border-radius: 8px; background-color: #161B22; border: 1px solid #1E2A3A; padding: 6px 10px;` with CSS class `track-card`. The energy mini-bar inside each card should use the parent block's accent colour. If the track cards are currently rendered as `Gtk.ListBox` rows, apply the `card` CSS class from libadwaita instead.

### Acceptance Criteria
Intro block card has a blue accent, Build purple, Peak orange, Outro green. Track cards in the timeline have a dark card background with rounded corners. The visual distinction between block types is clear at a glance. `uv run pytest tests/ -v` passes.

---
*Ralph Loop — multi-agent AI pair programming*