### PR TITLE
fix(gui): use Gdk.Display instead of Gtk.Display in _load_brand_css

### DIFF
--- a/playchitect/gui/app.py
+++ b/playchitect/gui/app.py
@@ -6,9 +6,10 @@ import gi
 # ruff: noqa: E402
 
 gi.require_version("Adw", "1")
+gi.require_version("Gdk", "4.0")
 gi.require_version("Gtk", "4.0")
 
-from gi.repository import Adw, Gio, Gtk  # type: ignore[unresolved-import]
+from gi.repository import Adw, Gdk, Gio, Gtk  # type: ignore[unresolved-import]
 
 from playchitect.gui.windows.main_window import PlaychitectWindow
 
@@ -20,7 +21,7 @@ def _load_brand_css() -> None:
     provider = Gtk.CssProvider()
     css_path = Path(__file__).parent / "style.css"
     provider.load_from_path(str(css_path))
-    display = Gtk.Display.get_default()
+    display = Gdk.Display.get_default()
     if display is not None:
         Gtk.StyleContext.add_provider_for_display(
             display,


### PR DESCRIPTION
## Bug

`playchitect-gui` crashes on startup with:

```
AttributeError: 'gi.repository.Gtk' object has no attribute 'Display'
```

`Gtk.Display` does not exist in GTK4. The correct class for display management is `Gdk.Display`.

## Fix

- Add `gi.require_version('Gdk', '4.0')`
- Import `Gdk` from `gi.repository`
- Change `Gtk.Display.get_default()` → `Gdk.Display.get_default()` in `_load_brand_css()`

Introduced in GUI-08 (`brand_css_dark_theme`, PR #213).