### PR TITLE
docs(planning): seed-playlist feature breakdown (#219)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,19 @@
+# Playchitect
+**Status:** paused
+**Priority:** medium
+**Progress:** ~20%
+**Last updated:** 2026-05-19
+**Repo:** `~/Programming/personal/playchitect`
+
+## What it does
+Game design tool; uses the ralph dev loop.
+
+## Why it matters
+Useful personal tool and test case for RalphZilla's autonomous dev loop.
+
+## Next actions
+- [ ] Resume once RalphZilla is stable enough to drive development
+- [ ] Define MVP scope
+
+## Notes
+<!-- Paused pending RalphZilla maturity -->

--- a/docs/planning/seed-playlist-feature.md
+++ b/docs/planning/seed-playlist-feature.md
@@ -1,0 +1,209 @@
+# Seed-based length-targeted playlist generation — feature plan
+
+*Tracking issue: #219*
+
+## Context
+
+Playchitect can already partition a whole library into K clusters and trim clusters to a
+target duration, but it has no way to do the thing users most often want: **"give me ~90
+minutes of music like *this* track."**
+
+- `core/clustering.py` partitions the *whole* library into K clusters; `--target-duration`
+  only chooses *how many* clusters, not the length of any single playlist.
+- `core/playlist_builder.py::build_duration_constrained_playlists` trims clusters to a length
+  by centroid distance, but it is wired into the GUI Playlists view only
+  (`gui/views/playlists_view.py:782`) and works per auto-discovered cluster.
+- There is **no "given a seed track, gather the most similar tracks and fill to a target
+  length" operation** anywhere.
+
+This feature adds that primitive in `core`, exposed through both the **CLI** and the **GUI**,
+reusing the existing feature/scaling/weighting/duration/sequencing machinery and returning a
+`ClusterResult` so export and GUI rendering work unchanged.
+
+**Confirmed decisions:** seed = a single track; the seed track is **included** in the result;
+both CLI and GUI surfaces.
+
+## How to read this breakdown
+
+Issues are grouped into **epics** and ordered by dependency. Each issue is sized for a junior
+developer and states, explicitly: **Deliverable**, **Reuse** (existing code to call instead of
+reinventing), **TDD tests** (written first, red → green), **Smoke / human testing**, and the
+**CLI / GUI / Docs** updates it needs (or "N/A").
+
+### Definition of Done (every issue)
+- Tests written first, all green: `uv run pytest <target> -o addopts="" -q`.
+- `uv run pre-commit run --all-files` clean (ruff, ty, unit, smoke hooks).
+- New/changed code >85% covered; complete type hints; no magic numbers (use named constants).
+- Docstrings updated for any touched public function.
+- Branch off `main` (`feature/219-<slug>`), PR opened, then `./scripts/review_pr.sh` for review.
+
+---
+
+## EPIC A — Core seed-similarity engine
+
+> Goal: a pure, surface-agnostic engine turning *(seed track, target length)* into an ordered,
+> length-correct `ClusterResult`. Build bottom-up so each piece is tested before the public
+> function ties them together.
+
+### Shared 8-D feature-vector helper
+- **Deliverable:** one helper, `build_feature_vector(metadata, features) -> np.ndarray | None`,
+  returning the same **8-D** vector clustering uses (BPM + the 7 intensity features, in
+  `weighting.FEATURE_NAMES` order). Place it where both `clustering.py` and the new module can
+  import it (e.g. a small `core/features.py`, or extend `weighting.py`). Refactor
+  `playlist_builder._features_to_vector` (currently 7-D, no BPM) and the clustering vector
+  assembly to call it — single source of truth.
+- **Reuse:** `weighting.FEATURE_NAMES`; `IntensityFeatures` fields (`rms_energy, brightness,
+  sub_bass_energy, kick_energy, bass_harmonics, percussiveness, onset_strength`);
+  `TrackMetadata.bpm`.
+- **TDD tests** (`tests/unit/test_features.py`): vector length 8; ordering matches
+  `FEATURE_NAMES`; BPM in the right slot; returns `None` when BPM/features missing; values
+  copied, not aliased.
+- **CLI:** N/A. **GUI:** N/A. **Docs:** docstring.
+- **Human testing:** none beyond review; existing clustering tests must stay green (proves the
+  refactor changed nothing).
+
+### Seed similarity ranking (scale + weight + distance)
+- **Deliverable:** internal `rank_by_similarity(seed_vec, candidate_vecs, *, genre,
+  weight_overrides) -> list[tuple[Path, float]]` (closest first). Fit `StandardScaler` on the
+  candidate matrix, transform seed + candidates, apply the weight vector, rank by weighted
+  Euclidean distance to the seed.
+- **Reuse:** `StandardScaler` pattern from `clustering.py`; `weighting.select_weights(...)` +
+  `weight_config.apply_weight_overrides(...)`; the ranking shape of
+  `playlist_builder._rank_tracks_by_distance`.
+- **TDD tests** (`tests/unit/test_seed_playlist.py::TestRanking`): identical-to-seed track
+  ranks ≈ 0 and first; deterministic ordering on synthetic features; changing weights changes
+  ordering; single-candidate and empty-candidate edge cases.
+- **CLI / GUI:** N/A. **Docs:** docstrings. **Human testing:** none (deterministic).
+
+### Duration-constrained assembly with seed included
+- **Deliverable:** internal `fill_to_duration(ranked, metadata_dict, target_secs, tolerance,
+  seed_path) -> list[Path]`. Greedily add nearest tracks until cumulative duration first
+  reaches `target_secs` within `±tolerance`; the seed is **always included**; skip
+  zero-/None-duration tracks.
+- **Reuse:** `playlist_builder._get_track_duration` and the cumulative-fill loop in
+  `build_duration_constrained_playlists`.
+- **TDD tests** (`...::TestFill`): total duration within `[target*(1-tol), target*(1+tol)]`
+  when the library is large enough; seed always present; target longer than the whole library
+  returns everything without erroring; zero-duration tracks skipped; tolerance boundary
+  respected.
+- **CLI / GUI:** N/A. **Docs:** docstrings. **Human testing:** none (deterministic).
+
+### Public `generate_playlist_from_seed` + sequencing + `ClusterResult`
+- **Deliverable:** `core/seed_playlist.py` exposing
+  `generate_playlist_from_seed(seed_path, candidate_features, metadata_dict,
+  target_duration_mins, *, genre=None, weight_overrides=None, tolerance=0.1,
+  sequence_mode="ramp") -> ClusterResult`. Compose the three helpers, order the chosen tracks
+  with the energy sequencer, and populate a `ClusterResult` (tracks, `total_duration`,
+  `centroid` = seed's scaled vector, auto name like `Like: <seed title>`).
+- **Reuse:** `sequencer` / `arc_sequencer` (modes ramp/peak/valley/wave/flat, matching the
+  Playlists view); `ClusterResult` dataclass.
+- **TDD tests** (`...::TestGenerate`): returns a `ClusterResult` with seed included and
+  duration within tolerance; `sequence_mode` reorders (ramp vs flat differ); invalid inputs
+  raise `ValueError` (seed absent from candidates, empty candidates, `target<=0`); the result
+  is consumable by `core/export.py` (write an M3U in the test).
+- **CLI / GUI:** N/A. **Docs:** module + function docstrings with an example.
+- **Human testing:** quick REPL run on a tiny real folder (≤20 tracks); record the command in
+  the PR.
+
+---
+
+## EPIC B — CLI surface
+
+> Goal: `playchitect playlist --seed <track> --duration <mins>` end to end.
+
+### `playlist` command skeleton, options & validation
+- **Deliverable:** new Click command in `cli/commands.py`: `--seed PATH` (required),
+  `--music-dir PATH` (required), `--duration FLOAT` minutes (required, >0), `--output PATH`
+  (optional), `--sequence [ramp|peak|valley|wave|flat]` (default `ramp`), `--genre TEXT`
+  (optional). Validate seed exists, music-dir exists, duration > 0; clear errors with non-zero
+  exit.
+- **Reuse:** option/validation style of the existing `scan` command (`commands.py:34`).
+- **TDD tests** (`tests/integration/test_cli_playlist.py`, `CliRunner`): `--help` lists the
+  command; missing/invalid `--seed`, missing `--music-dir`, `--duration 0` each fail helpfully
+  with non-zero exit.
+- **CLI:** the work itself. **GUI:** N/A. **Docs:** stub into `docs/guide/cli-reference.md`.
+- **Human testing:** `uv run playchitect playlist --help` reads correctly.
+
+### CLI library loading, generation & export wiring
+- **Deliverable:** command body — discover the library, gather metadata + intensity features
+  (using the cache), call `generate_playlist_from_seed`, export the `ClusterResult`, print a
+  short summary (track count, total minutes, output path). Default output name if `--output`
+  omitted; support `.cue` when the output extension is `.cue`.
+- **Reuse:** `audio_scanner`, `metadata_extractor`, `intensity_analyzer` (+ JSON cache) — same
+  loading path `scan` uses; `core/export.py` for M3U/CUE.
+- **TDD tests** (`tests/integration/test_cli_playlist.py`): with a small fixture library + a
+  seed, exit 0, M3U written that contains the seed and totals ≈ target within tolerance;
+  unreadable/0-track library handled gracefully.
+- **CLI:** complete behaviour. **GUI:** N/A.
+- **Docs:** full `playlist` section in `docs/guide/cli-reference.md` per `UPDATING_DOCS.md`
+  (synopsis, every flag, worked example); update the command docstring.
+- **Human testing:** `uv run playchitect playlist --seed "<real track>" --music-dir ~/Music
+  --duration 90 --output /tmp/like-this.m3u`; open the M3U and confirm ~90 min of audibly
+  similar tracks including the seed. Record in PR.
+
+---
+
+## EPIC C — GUI surface
+
+> Goal: from the Library view, pick a track → "Make playlist like this…" → choose a length →
+> see the result. Mirror existing patterns; reuse the Playlists view to display results.
+
+### Library view "Make playlist like this…" action + dialog
+- **Deliverable:** in `gui/views/library_view.py`, add a header button **and** right-click
+  context entry "Make playlist like this…", enabled only when exactly one track is selected.
+  Clicking opens a small modal with target length (30/60/90/120/Custom minutes) and sequence
+  mode (ramp/peak/valley/wave/flat); it returns the chosen values via a callback. No generation
+  logic here (stub the handler).
+- **Reuse:** existing libadwaita dialog/widget patterns in `gui/` (preferences window,
+  Playlists header controls).
+- **GUI smoke tests** (`tests/gui/test_library_seed_action.py`, mock harness): action exists;
+  disabled with no selection, enabled with one; dialog constructs and exposes the selected
+  length + sequence values.
+- **CLI:** N/A. **GUI:** the work itself. **Docs:** note the new control (full page in Epic D).
+- **Human testing:** launch `uv run playchitect-gui`, select a track, open the dialog, confirm
+  controls behave (no generation yet).
+
+### GUI background generation & result display
+- **Deliverable:** wire the dialog callback to run `generate_playlist_from_seed` on a
+  background thread, then hand the resulting `ClusterResult` to the Playlists view and switch to
+  it. Spinner/disabled state while running; error toast on failure. Features/metadata come from
+  the already-loaded library state.
+- **Reuse:** the background-thread + main-thread-callback pattern in
+  `gui/views/playlists_view.py` (~line 782); the Playlists view's `ClusterResult` rendering.
+- **GUI smoke tests:** completion callback populates the Playlists view with the result;
+  failure path shows an error and re-enables the control (worker run synchronously / mocked).
+- **CLI:** N/A. **GUI:** the work itself. **Docs:** covered in Epic D.
+- **Human testing:** in the running GUI, select a track → "Make playlist like this…" → 90 min →
+  confirm a coherent set appears in Playlists and can be exported. Record in PR.
+
+---
+
+## EPIC D — Documentation & status reconciliation
+
+> Goal: make the project's own docs trustworthy and document the new feature.
+
+### Reconcile project status docs
+- **Deliverable:** fix `STATUS.md` (description = Smart DJ Playlist Manager, not "game design
+  tool"; status `active`; realistic progress; accurate next actions). Update
+  `docs/planning/ROADMAP.md` so the Milestone 7 GUI views are marked built/merged, and add this
+  seed-playlist feature.
+- **TDD / CLI / GUI:** N/A. **Human testing:** James confirms both match reality.
+
+### User & developer documentation for the feature
+- **Deliverable:** a user-guide page/section covering both surfaces (CLI `playlist` command and
+  the GUI "Make playlist like this…" flow), added to VitePress per `UPDATING_DOCS.md` and the
+  `docs/.vitepress/config.ts` sidebar. Finalize `cli-reference.md`. Confirm touched docstrings.
+- **TDD:** N/A. **CLI / GUI:** documentation of both.
+- **Human testing:** the docs site builds and the new page renders in the nav.
+
+---
+
+## Suggested delivery order & PR slicing
+1. **Epic A** as one PR (the four issues are tightly coupled — ship the engine together, commit
+   per issue for reviewable history). Land green before anything depends on it.
+2. **Epic B** as one PR (depends on A).
+3. **Epic C** as one PR — split into its two issues if review gets large (depends on A).
+4. **Epic D** as one PR (can start in parallel; the status-doc fix needs no code).
+
+Each PR: TDD first, smoke tests, the human-test command/result pasted into the PR body, then
+`./scripts/review_pr.sh` before squash-merge to `main`.

--- a/prd.json
+++ b/prd.json
@@ -1,825 +1,150 @@
 {
   "project": "playchitect",
-  "description": "Smart DJ Playlist Manager using K-means clustering on multi-dimensional audio features (BPM + 7 intensity features) to generate coherent playlists via a GTK4 + libadwaita GUI and a Click CLI.",
+  "description": "Smart DJ Playlist Manager — adds seed-based length-targeted playlist generation: given a single track and a target duration, gather the most sonically similar library tracks and fill a playlist to that length, then sequence by energy arc.",
   "quality_checks": [
-    "uv run pytest tests/ -v",
+    "uv run pytest tests/ -o addopts='' -q",
     "uv run pre-commit run --all-files"
   ],
   "tasks": [
     {
-      "id": "FIX-04",
-      "epic": "Stability",
-      "title": "fix_vorbis_valueerror_in_extract_text_tag",
-      "owner": "ralph",
-      "description": "In playchitect/core/metadata_extractor.py, _extract_text_tag() uses `if tag in audio` (line ~301) which triggers mutagen's __contains__ -> __getitem__ -> ValueError on Vorbis-comment FLAC files. Wrap the tag lookup in a try/except: replace `if tag in audio: value = audio[tag]` with a try/except (ValueError, KeyError) block that continues to the next tag name on exception. This silences the spurious bare ValueError and allows extraction to complete for genre, mood, and any other tags that follow.",
-      "acceptance_criteria": "tests/unit/test_metadata_extractor.py: add a test where a mock mutagen object's __contains__ raises ValueError; assert _extract_text_tag returns None instead of propagating. Scanning a FLAC library no longer logs \"Error extracting metadata from ...:\" with an empty message. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 1,
-      "note": "GitHub issue #176"
-    },
-    {
-      "id": "FIX-05",
-      "epic": "Stability",
-      "title": "fix_selection_changed_signature_library_view",
-      "owner": "ralph",
-      "description": "In playchitect/gui/views/library_view.py, _on_selection_changed() is defined with only 2 parameters (self, selection, _position) but Gtk.SingleSelection emits selection-changed with 3 arguments (selection, position, n_items). Add the missing _n_items: int parameter to the method signature.",
-      "acceptance_criteria": "Clicking a track in LibraryView no longer raises TypeError. tests/gui/test_library_view.py: add or update a test that calls _on_selection_changed with 3 arguments and asserts track-selected is emitted. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 1,
-      "note": "GitHub issue #178"
-    },
-    {
-      "id": "FIX-06",
-      "epic": "Stability",
-      "title": "fix_suggest_blocks_empty_slice_valueerror",
-      "owner": "ralph",
-      "description": "In playchitect/core/energy_blocks.py, suggest_blocks() crashes with ValueError: min() iterable argument is empty when a small library produces a peak_clusters slice that is empty despite peak_end > build_end passing. Fix: change each block section guard from \"if peak_end > build_end\" to \"if peak_clusters\" (check the slice itself is non-empty) before calling min()/max(). Apply the same defensive guard to the build, peak, sustain, and outro block sections.",
-      "acceptance_criteria": "suggest_blocks() with 1 cluster returns a list without raising. Add test: suggest_blocks with a single cluster. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 1,
-      "note": "GitHub issue #179"
-    },
-    {
-      "id": "FIX-01",
-      "epic": "Stability",
-      "title": "downgrade_pca_bootstrap_warning",
-      "owner": "ralph",
-      "description": "In playchitect/core/weighting.py line 115, change `logger.warning(\"PCA bootstrap CI too wide; falling back to heuristic/uniform\")` to `logger.info(...)`. This message fires during normal operation (not enough tracks for tight CI) and is not actionable \u2014 emitting it as WARNING pollutes CLI and GUI log output on typical-sized libraries. No other changes.",
-      "acceptance_criteria": "tests/unit/test_weighting.py: existing tests still pass. Running `uv run playchitect scan` on a small folder no longer produces a WARNING log line containing 'PCA bootstrap'. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 1,
-      "note": "GitHub issue #108"
-    },
-    {
-      "id": "FIX-02",
-      "epic": "Stability",
-      "title": "handle_corrupt_audio_gracefully",
-      "owner": "ralph",
-      "description": "In playchitect/core/intensity_analyzer.py, wrap the `librosa.load()` call inside `IntensityAnalyzer.analyze()` in a broad try/except that catches: `audioread.exceptions.NoBackendError`, `soundfile.LibsndfileError`, `ValueError`, `RuntimeError`, `OSError`, and a bare `Exception` fallback. On any exception: call `logger.warning(f\"Skipping corrupt file {path}: {e}\")` and return a zero-vector `IntensityFeatures` (all float fields = 0.0, `file_hash` = empty string, `filepath` = the path). Also guard the worker function `_analyze_worker` so that a per-file failure returns `(filepath_str, None)` rather than propagating. In `analyze_batch()`, skip entries where the result is None and log a summary count. Add unit tests in tests/unit/test_intensity_analyzer.py that mock `librosa.load` to raise each exception type and assert `analyze()` returns an `IntensityFeatures` with `rms_energy == 0.0` without raising.",
-      "acceptance_criteria": "tests/unit/test_intensity_analyzer.py: mock librosa.load raising ValueError, OSError, RuntimeError each returns a zero-vector IntensityFeatures. analyze_batch() with one corrupt entry completes and returns results for the valid entries. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 1,
-      "note": "GitHub issue #95"
-    },
-    {
-      "id": "FIX-03",
-      "epic": "Stability",
-      "title": "suppress_librosa_warnings_in_batch",
-      "owner": "ralph",
-      "description": "playchitect/utils/warnings.py already exports `suppress_librosa_warnings`. Verify it is applied in both the single-file `IntensityAnalyzer.analyze()` path and the ProcessPoolExecutor worker `_analyze_worker()`. If not already applied inside the worker, add `with suppress_librosa_warnings():` around the `librosa.load` + feature-extraction calls inside `_analyze_worker`. Also apply the suppression inside `IntensityAnalyzer.analyze()` if it is not already there. Do NOT modify suppress_librosa_warnings itself. Add a test that calls `analyze()` on a real (non-corrupt) audio fixture and asserts no WARNING-level log records are emitted by the `audioread` or `soundfile` loggers.",
-      "acceptance_criteria": "tests/unit/test_intensity_analyzer.py: analyze() on a valid fixture file emits no warnings from audioread/soundfile loggers. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 1,
-      "note": "GitHub issue #94"
-    },
-    {
       "id": "TASK-01",
-      "epic": "Core Config & CLI",
-      "title": "yaml_weight_overrides",
+      "epic": "Tests — Core",
+      "title": "test_feature_vector_helper",
       "owner": "ralph",
-      "description": "Implement user-configurable feature weight overrides via YAML. (1) Create playchitect/utils/weight_config.py. Add a `WeightOverrides` dataclass with optional float fields matching `FEATURE_NAMES` from weighting.py: `bpm`, `rms_energy`, `brightness`, `sub_bass`, `kick_energy`, `bass_harmonics`, `percussiveness`, `onset_strength` \u2014 all default to `None`. (2) Add `load_weight_overrides(path: Path) -> WeightOverrides` that reads a YAML file under key `weights:` (use `tomllib` or `yaml`; prefer stdlib `tomllib` if TOML, but the file format is YAML so use PyYAML which is already available as a transitive dep \u2014 check pyproject.toml first; if not present add it). (3) Add `apply_weight_overrides(weights: np.ndarray, overrides: WeightOverrides, feature_names: tuple[str, ...]) -> np.ndarray` that replaces entries where the override is not None. (4) In `PlaylistClusterer.__init__` in clustering.py add optional param `weight_overrides: WeightOverrides | None = None`; after `select_weights()` call `apply_weight_overrides()` when not None. (5) Create `data/weight_config.example.yaml` showing all 8 keys with inline comments. Add unit tests in tests/unit/test_weight_config.py.",
-      "acceptance_criteria": "tests/unit/test_weight_config.py: load_weight_overrides parses a YAML with `weights: {bpm: 2.0}` and returns WeightOverrides(bpm=2.0, rms_energy=None, ...). apply_weight_overrides replaces only non-None entries. PlaylistClusterer respects overrides when passed. data/weight_config.example.yaml exists. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 2,
-      "note": "GitHub issue #26"
+      "description": "Write tests/unit/test_feature_vector.py. This test file covers a single helper function that does not exist yet: build_feature_vector(metadata: TrackMetadata, features: IntensityFeatures) -> np.ndarray | None. The function will live in playchitect/core/features.py (also does not exist yet — import will fail until TASK-02 creates it). Write the tests so they import from playchitect.core.features and describe what the function must do:\n\n1. Returns an np.ndarray of length 8.\n2. The 8 values are, in this exact order (matching weighting.FEATURE_NAMES = ('bpm', 'rms_energy', 'brightness', 'sub_bass', 'kick_energy', 'bass_harmonics', 'percussiveness', 'onset_strength')): metadata.bpm, features.rms_energy, features.brightness, features.sub_bass_energy, features.kick_energy, features.bass_harmonics, features.percussiveness, features.onset_strength.\n3. Returns None when metadata.bpm is None.\n4. Returns None when features is None.\n5. The returned array is a copy — mutating it does not change the original feature values.\n\nUse the existing make_metadata and make_intensity helpers from tests/unit/test_playlist_builder.py as a reference for how to construct TrackMetadata and IntensityFeatures test fixtures (copy the helper functions into this file; do NOT import them from test_playlist_builder).\n\nThese tests must FAIL at collection time (ImportError) until TASK-02 is merged. That is expected and correct — TDD red phase.",
+      "acceptance_criteria": "tests/unit/test_feature_vector.py collects with no syntax errors but all tests fail at import with ModuleNotFoundError or ImportError because playchitect/core/features.py does not yet exist. The test file covers: correct length (8), correct ordering of all 8 fields, None returned when bpm missing, None returned when features is None, returned array is a copy.",
+      "completed": false,
+      "priority": 1
     },
     {
       "id": "TASK-02",
-      "epic": "Core Config & CLI",
-      "title": "cli_weight_flags",
+      "epic": "Core — Feature vector",
+      "title": "feature_vector_helper",
       "owner": "ralph",
-      "description": "Extend the `scan` Click command in playchitect/cli/commands.py with two new options: (1) `--weight-file PATH` (type=click.Path(exists=True, path_type=Path), default=None) \u2014 loads WeightOverrides from the YAML file (from TASK-01) and passes it to PlaylistClusterer via the new `weight_overrides` param. (2) `--learn-weights / --no-learn-weights` boolean flag (default True) \u2014 controls whether EWKM per-cluster weight refinement runs. Currently EWKM is always attempted when `n_tracks >= _MIN_TRACKS_EWKM`; gate it behind this flag by adding `use_ewkm: bool = True` to PlaylistClusterer.__init__ and skip the ewkm_refine call when False. Wire both flags through. Add integration tests in tests/integration/test_cli_weight_flags.py that invoke the CLI via Click's test runner (CliRunner) with `--weight-file` pointing at a minimal YAML fixture and `--no-learn-weights`, asserting exit code 0.",
-      "acceptance_criteria": "tests/integration/test_cli_weight_flags.py: CliRunner invocation with --weight-file + minimal YAML exits 0. --no-learn-weights exits 0 without error. `playchitect scan --help` output includes both flags. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 2,
-      "note": "GitHub issue #27"
-    },
-    {
-      "id": "TASK-09",
-      "epic": "Advanced Audio Analysis",
-      "title": "key_harmonic_features",
-      "owner": "ralph",
-      "description": "Add musical key detection to IntensityFeatures. (1) In playchitect/core/intensity_analyzer.py, inside `IntensityAnalyzer.analyze()`, add after existing feature extraction: compute `librosa.feature.chroma_cqt(y=y, sr=sr)` \u2192 `chroma_mean = chroma.mean(axis=1)` (12-bin vector). Determine dominant chroma bin (`np.argmax(chroma_mean)`). Map to Camelot Wheel: define a module-level dict `_CHROMA_TO_CAMELOT: dict[int, tuple[str, int]]` mapping chroma index 0\u201311 to (camelot_str, key_index) e.g. `{0: ('8B', 0), 1: ('3B', 1), 2: ('10B', 2), 3: ('5B', 3), 4: ('12B', 4), 5: ('7B', 5), 6: ('2B', 6), 7: ('9B', 7), 8: ('4B', 8), 9: ('11B', 9), 10: ('6B', 10), 11: ('1B', 11)}` (major only; minor would need mode detection \u2014 out of scope). (2) Add `camelot_key: str` and `key_index: float` fields to `IntensityFeatures`. (3) Add `harmonic_compatibility(key_a: str, key_b: str) -> bool` module-level function: compatible if same number (\u00b10 letter change), adjacent number (\u00b11 same letter), or same letter (\u00b11 number) per Camelot rules. (4) Persist `camelot_key` and `key_index` in the JSON cache. (5) Add unit tests in tests/unit/test_intensity_analyzer.py with a synthetic chroma fixture that pegs bin 0 and asserts camelot_key == '8B'.",
-      "acceptance_criteria": "tests/unit/test_intensity_analyzer.py: mock chroma returning max at bin 0 \u2192 camelot_key='8B', key_index=0.0. harmonic_compatibility('8B', '9B') is True. harmonic_compatibility('8B', '1B') is False. JSON cache round-trip includes camelot_key. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 4,
-      "note": "GitHub issue #36"
-    },
-    {
-      "id": "TASK-11",
-      "epic": "Advanced Audio Analysis",
-      "title": "energy_flow_features",
-      "owner": "ralph",
-      "description": "Add energy flow features to IntensityFeatures in playchitect/core/intensity_analyzer.py. (1) Add three new fields to `IntensityFeatures` dataclass: `dynamic_range: float` (0\u20131), `energy_gradient: float` (-1 to 1), `drop_density: float` (0\u20131, normalised drops/min). (2) In `analyze()`, after computing `rms_energy`, compute: `rms_frames = librosa.feature.rms(y=y, frame_length=2048, hop_length=512)[0]`; `dynamic_range = float(np.clip((rms_frames.max() - rms_frames.min()) / (_RMS_NORM_FACTOR + 1e-9), 0, 1))`; `energy_gradient`: fit `np.polyfit(np.arange(len(rms_frames)), rms_frames, 1)[0]`, normalise to [-1, 1] by clipping at \u00b10.001 then dividing; `drop_density`: count frames where `rms_frames > rms_frames.mean() + 2*rms_frames.std()` divided by track duration in minutes, normalise to [0, 1] by clipping at 10 drops/min. (3) Add `dynamic_range`, `energy_gradient`, `drop_density` to the JSON cache schema (add to `to_dict()` and `from_dict()`/constructor). (4) Update `to_feature_vector()` to NOT include these in the main feature vector (they are metadata, not clustering dimensions). (5) Update any cache loading code to handle old cache files missing these keys (default 0.0). Add unit tests.",
-      "acceptance_criteria": "tests/unit/test_intensity_analyzer.py: a synthetic sine-wave y yields dynamic_range >= 0, energy_gradient is a float, drop_density >= 0. Old cache files missing new keys load without KeyError (default to 0.0). `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 4,
-      "note": "GitHub issue #38"
-    },
-    {
-      "id": "TASK-13",
-      "epic": "Advanced Audio Analysis",
-      "title": "timbre_texture_features",
-      "owner": "ralph",
-      "description": "Add timbre/texture features to IntensityFeatures in playchitect/core/intensity_analyzer.py. (1) Add four new metadata fields to `IntensityFeatures` (NOT part of the main clustering feature vector): `spectral_flatness: float` (0\u20131), `zero_crossing_rate: float` (0\u20131), `mfcc_variance: float` (0\u20131), `spectral_rolloff_85: float` (0\u20131, normalised to Nyquist). (2) In `analyze()`, compute: `spectral_flatness = float(np.mean(librosa.feature.spectral_flatness(y=y)))`  normalised to [0,1] by clipping at 0.5; `zcr = float(np.mean(librosa.feature.zero_crossing_rate(y=y)[0]))` normalised to [0,1] by clipping at 0.5; `mfcc_var = float(np.mean(np.var(librosa.feature.mfcc(y=y, sr=sr, n_mfcc=13), axis=1)))` normalised to [0,1] by dividing by 100 and clipping; `sr_85 = float(np.mean(librosa.feature.spectral_rolloff(y=y, sr=sr, roll_percent=0.85)[0])) / (sr/2)` clamped 0\u20131. (3) Add all four to JSON cache, handle old cache gracefully. (4) Do NOT add to `to_feature_vector()`. Add unit tests.",
-      "acceptance_criteria": "tests/unit/test_intensity_analyzer.py: analysis of a synthetic y yields all four fields in [0, 1]. Old cache missing new keys loads as 0.0. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 4,
-      "note": "GitHub issue #40"
-    },
-    {
-      "id": "TASK-15",
-      "epic": "Advanced Audio Analysis",
-      "title": "structural_vocal_features",
-      "owner": "ralph",
-      "description": "Add structural/vocal features to IntensityFeatures (requires TASK-11 baseline pattern). (1) Add two new metadata fields (not in feature vector): `vocal_presence: float` (0\u20131), `intro_length_secs: float` (seconds). (2) In `analyze()`: for `vocal_presence`, run `librosa.effects.hpss(y)` to get `y_harmonic`; compute `harmonic_spec = np.abs(librosa.stft(y_harmonic))`; find frequency bins for 200\u2013800Hz using `librosa.fft_frequencies(sr=sr)`; `vocal_energy = harmonic_spec[vocal_bins].sum()`; `total_harmonic_energy = harmonic_spec.sum() + 1e-9`; `vocal_presence = float(np.clip(vocal_energy / total_harmonic_energy * 10, 0, 1))` (scale factor 10 because vocal band is a subset). For `intro_length_secs`: use `rms_frames` (already computed in energy_gradient step \u2014 share computation); `threshold = 0.5 * np.mean(rms_frames)`; `intro_frames = np.argmax(rms_frames > threshold)`; `intro_length_secs = float(intro_frames * 512 / sr)`. (3) Add to JSON cache, handle missing keys as 0.0. Add unit tests.",
-      "acceptance_criteria": "tests/unit/test_intensity_analyzer.py: synthetic y with a loud harmonic mid-range yields vocal_presence > 0. Silent prefix followed by loud portion yields intro_length_secs > 0. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 4,
-      "note": "GitHub issue #42"
-    },
-    {
-      "id": "TASK-17",
-      "epic": "Advanced Audio Analysis",
-      "title": "audio_mood_detection",
-      "owner": "ralph",
-      "description": "Add rule-based mood detection to IntensityFeatures (does not require essentia/MusiCNN \u2014 use features already computed). (1) Add `mood_label: str` field to `IntensityFeatures` (not in feature vector). (2) Create playchitect/core/mood_classifier.py with `classify_mood(features: IntensityFeatures) -> str`. Use a decision-tree of feature thresholds to return one of 8 mood labels: 'Dark' (low brightness < 0.3, low vocal_presence < 0.3), 'Euphoric' (high energy > 0.7, high brightness > 0.6), 'Melancholic' (low energy < 0.3, high vocal_presence > 0.5), 'Aggressive' (high percussiveness > 0.7, high onset_strength > 0.6), 'Dreamy' (low percussiveness < 0.3, high brightness > 0.5), 'Hypnotic' (mid energy 0.3\u20130.6, low dynamic_range < 0.3), 'Groovy' (mid-high percussiveness > 0.5, mid energy 0.4\u20130.7), 'Ethereal' (catch-all). Handle missing vocal_presence/dynamic_range as 0.0 for backwards compat. (3) In `analyze()`, call `classify_mood(features)` after all feature computation and set `mood_label`. (4) Add 'Mood' column to LibraryView ColumnView and PlaylistsView ColumnView. (5) Add mood to JSON cache. Add unit tests.",
-      "acceptance_criteria": "tests/unit/test_mood_classifier.py: synthetic IntensityFeatures with high percussiveness + high onset returns 'Aggressive'. Default low-everything returns 'Ethereal'. Mood column renders in both views. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 4,
-      "note": "GitHub issue #102"
-    },
-    {
-      "id": "TASK-18",
-      "epic": "Advanced Audio Analysis",
-      "title": "energy_arc_selector",
-      "owner": "ralph",
-      "description": "Implement the Visual Energy Arc Selector for the Playlists view (requires TASK-05). (1) Create playchitect/core/arc_sequencer.py. Define `EnergyArcPreset(name: str, description: str, arc_curve: list[float])` dataclass (arc_curve is normalised 0\u20131 values, one per expected cluster position). Define `BUILTIN_PRESETS: list[EnergyArcPreset]` with 5 entries: Warmup Ramp [0.2,0.4,0.6,0.8,1.0], Peak Hour [0.4,0.7,1.0,1.0,0.8], Sunrise [0.6,0.4,0.2,0.4,0.8], Deep Journey [0.5,0.3,0.4,0.6,0.5], Closing Down [1.0,0.9,0.7,0.5,0.3]. Implement `apply_arc(clusters: list[ClusterResult], preset: EnergyArcPreset) -> list[ClusterResult]`: sort clusters by mean rms_energy, then assign each to the arc position it best matches (greedy closest-value). (2) In PlaylistsView toolbar add a `Gtk.DropDown` labelled 'Arc' listing preset names + 'None'. Wire selection to `apply_arc` call after clustering. (3) Add unit tests for `apply_arc`.",
-      "acceptance_criteria": "tests/unit/test_arc_sequencer.py: apply_arc with Warmup Ramp on 5 clusters of ascending energies returns them in ascending order. apply_arc with Closing Down returns them in descending order. PlaylistsView smoke shows Arc DropDown. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 4,
-      "note": "GitHub issue #106"
-    },
-    {
-      "id": "TASK-20",
-      "epic": "Advanced Audio Analysis",
-      "title": "five_rhythms_sequencing",
-      "owner": "ralph",
-      "description": "Implement the 5 Rhythms sequencing mode in playchitect/core/sequencer.py (requires TASK-15 for vocal_presence). (1) Add `FiveRhythmsPhase` StrEnum: FLOWING='flowing', STACCATO='staccato', CHAOS='chaos', LYRICAL='lyrical', STILLNESS='stillness'. (2) Add module-level `_FIVE_RHYTHMS_THRESHOLDS` dict mapping phase to BPM and energy criteria. (3) Add `classify_five_rhythms_phase(bpm: float, rms_energy: float) -> FiveRhythmsPhase`: Flowing = bpm 85\u2013115 and rms < 0.5; Staccato = bpm 115\u2013135 and rms 0.4\u20130.7; Chaos = bpm > 135 or rms > 0.75; Stillness = bpm < 85 or rms < 0.25; Lyrical = everything else. (4) Add `sequence_five_rhythms(tracks: list[Path], features: dict[Path, IntensityFeatures]) -> list[Path]`: group tracks by phase; order groups Flowing \u2192 Staccato \u2192 Chaos \u2192 Lyrical \u2192 Stillness; within each group sort by energy ascending; concatenate. If a phase has no tracks, skip it. (5) Add 'Five Rhythms' to the Sort DropDown in PlaylistsView (TASK-12). (6) Add unit tests with 5 synthetic IntensityFeatures covering each phase.",
-      "acceptance_criteria": "tests/unit/test_sequencer.py: sequence_five_rhythms on 5 tracks (one per phase) returns Flowing first, Stillness last. classify_five_rhythms_phase(90, 0.3) == FLOWING. classify_five_rhythms_phase(145, 0.8) == CHAOS. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 4,
-      "note": "GitHub issue #51"
-    },
-    {
-      "id": "TASK-22",
-      "epic": "Interactive Set Building",
-      "title": "compatibility_and_next_track",
-      "owner": "ralph",
-      "description": "Implement track compatibility scoring and next-track suggestions (requires TASK-09 for camelot_key). (1) Create playchitect/core/compatibility.py. Implement `compatibility_score(feat_a: IntensityFeatures, feat_b: IntensityFeatures) -> float`: weighted combination of four components: `bpm_score = max(0, 1 - abs(feat_a.bpm - feat_b.bpm) / 20)` (note: bpm is on TrackMetadata, not IntensityFeatures \u2014 accept both as `bpm_a: float, bpm_b: float` additional args OR use a `TrackInfo` typed-dict combining both); `key_score = 1.0 if harmonic_compatibility(feat_a.camelot_key, feat_b.camelot_key) else 0.0`; `energy_score = 1 - abs(feat_a.rms_energy - feat_b.rms_energy)`; `timbre_score = 1 - abs(feat_a.brightness - feat_b.brightness)`. Final: `0.3*bpm_score + 0.3*key_score + 0.25*energy_score + 0.15*timbre_score`. (2) Implement `next_track_suggestions(current_path: Path, current_features: IntensityFeatures, current_bpm: float, candidates: list[tuple[Path, IntensityFeatures, float]], n: int = 5) -> list[tuple[Path, float]]`: returns top-n (path, score) sorted descending. (3) In SetBuilderView, add a 'Next Track' `Gtk.Expander` below the block strip: when a track in the timeline is selected, show top-5 candidates as rows with title, artist, and score bar. (4) Add unit tests.",
-      "acceptance_criteria": "tests/unit/test_compatibility.py: same BPM + compatible key + same energy returns score > 0.8. Incompatible key + large BPM diff returns score < 0.4. next_track_suggestions returns exactly n results sorted descending. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 5,
-      "note": "GitHub issue #100"
-    },
-    {
-      "id": "TASK-27",
-      "epic": "DJ Ecosystem Integration",
-      "title": "history_aware_sequencing",
-      "owner": "ralph",
-      "description": "Implement history-aware 'Fresh Tracks' sequencing. (1) Create playchitect/core/play_history.py. Implement `PlayHistory` class: `__init__(history_path: Path = Path.home() / '.cache' / 'playchitect' / 'play_history.json')`. Methods: `load() -> None` (reads JSON dict `{path_str: {times_used: int, last_used: str ISO8601}}`; creates empty if missing); `record(track_path: Path) -> None` (increment times_used, set last_used to today); `get_freshness_score(track_path: Path) -> float` (1.0 if never used; otherwise `max(0.0, 1.0 - log(times_used + 1) / log(31)) * days_decay` where `days_decay = min(1.0, days_since_use / 30.0)`); `save() -> None`. (2) In playchitect/core/sequencer.py, add `sequence_fresh(tracks: list[Path], features: dict[Path, IntensityFeatures], history: PlayHistory) -> list[Path]`: sort by `history.get_freshness_score(p) * rms_energy` descending, excluding tracks with score < 0.1. (3) In PlaylistsView, add a 'Prefer fresh tracks' `Gtk.Switch` to the toolbar. When on, call `sequence_fresh`. After export, call `history.record()` for each exported track. (4) Add unit tests for PlayHistory.",
-      "acceptance_criteria": "tests/unit/test_play_history.py: freshness_score for unseen track is 1.0. After record() called once, score is < 1.0. After 30 days (mock date), score approaches 1.0 again. sequence_fresh excludes tracks with score < 0.1. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 6,
-      "note": "GitHub issue #83"
-    },
-    {
-      "id": "TASK-29",
-      "epic": "Intelligent Playlist Naming",
-      "title": "vibe_profiling_salience_scoring",
-      "owner": "ralph",
-      "description": "Implement vibe profiling and salience scoring as data layer for playlist naming. (1) Create playchitect/core/naming/__init__.py and playchitect/core/naming/vibe_profiler.py. Define `VibeProfile` dataclass: `cluster_id: int`, `mean_bpm: float`, `mean_rms: float`, `mean_brightness: float`, `mean_percussiveness: float`, `mean_vocal_presence: float`, `dominant_mood: str`, `mood_distribution: dict[str, float]` (mood \u2192 fraction of tracks). Implement `compute_vibe_profile(cluster: ClusterResult, features: dict[Path, IntensityFeatures], metadata: dict[Path, TrackMetadata]) -> VibeProfile`: average each feature field across all tracks in the cluster; compute `dominant_mood` as the most frequent `mood_label` across tracks. Implement `score_salience(profile: VibeProfile, library_profiles: list[VibeProfile]) -> dict[str, float]`: compute library mean and std for mean_bpm, mean_rms, mean_brightness, mean_percussiveness, mean_vocal_presence; return a dict mapping feature_name \u2192 z-score for this profile; only return entries with abs(z) > 1.5. Add `bucket_bpm(bpm: float) -> str`: <100='Slow', 100\u2013120='Mid-Tempo', 120\u2013135='Peak Hour', >135='High Energy'. Add `bucket_energy(rms: float) -> str`: <0.3='Subtle', 0.3\u20130.5='Groovy', 0.5\u20130.7='Energetic', >0.7='Intense'. Add unit tests.",
-      "acceptance_criteria": "tests/unit/test_vibe_profiler.py: compute_vibe_profile on a 3-track cluster returns correct mean_bpm. score_salience returns empty dict when all profiles are identical. bucket_bpm(125) == 'Peak Hour'. bucket_energy(0.8) == 'Intense'. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 7,
-      "note": "GitHub issue #119 (sub-task of #104)"
-    },
-    {
-      "id": "TASK-30",
-      "epic": "Intelligent Playlist Naming",
-      "title": "grammar_engine",
-      "owner": "ralph",
-      "description": "Implement linguistic grammar engine for natural-sounding playlist names. Do NOT use spaCy (avoids a large optional dependency). Use pure Python. (1) Create playchitect/core/naming/grammar_engine.py. Implement `ROYAL_ORDER: list[str]` = ['Opinion', 'Size', 'Age', 'Shape', 'Color', 'Origin', 'Material', 'Purpose']. Define `WORD_CATEGORIES: dict[str, str]` mapping ~40 adjective words to a Royal Order category, e.g. {'Dark': 'Opinion', 'Ethereal': 'Opinion', 'Minimal': 'Opinion', 'Deep': 'Opinion', 'Intense': 'Opinion', 'Subtle': 'Opinion', 'Vast': 'Size', 'Dense': 'Size', 'Late': 'Age', 'Ancient': 'Age', 'Geometric': 'Shape', 'Flowing': 'Shape', 'Midnight': 'Color', 'Amber': 'Color', 'Nordic': 'Origin', 'Urban': 'Origin', 'Metallic': 'Material', 'Organic': 'Material', 'Driving': 'Purpose', 'Hypnotic': 'Purpose'}. Implement `SYNONYMS: dict[str, list[str]]` for ~15 common words that might repeat. Implement `sort_by_royal_order(words: list[str]) -> list[str]`: words not in WORD_CATEGORIES go last. Implement `pick_synonym(word: str, used: set[str]) -> str`: returns a synonym from SYNONYMS[word] not in `used`, or the original if none available. Implement `indefinite_article(word: str) -> str`: 'an' if word[0] in 'AEIOU' else 'a'. Implement `generate_name(descriptors: list[str], noun: str, used_names: set[str] = set()) -> str`: sort descriptors by royal order, apply synonym picking, join as '{descriptors} {noun}' (title-case). (2) Add unit tests in tests/unit/test_grammar_engine.py.",
-      "acceptance_criteria": "tests/unit/test_grammar_engine.py: sort_by_royal_order(['Driving', 'Dark', 'Nordic']) returns ['Dark', 'Nordic', 'Driving'] (Opinion < Origin < Purpose). generate_name(['Dark', 'Driving'], 'Journey', set()) returns a non-empty title-case string. pick_synonym('Dark', {'Shadowed'}) does not return 'Shadowed'. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 7,
-      "note": "GitHub issue #120 (sub-task of #104)"
-    },
-    {
-      "id": "TASK-31",
-      "epic": "Intelligent Playlist Naming",
-      "title": "intelligent_playlist_namer",
-      "owner": "ralph",
-      "description": "Wire vibe profiler and grammar engine into a complete naming system (requires TASK-29 and TASK-30). (1) Create playchitect/core/naming/playlist_namer.py. Define `TAG_TO_DESCRIPTORS: dict[str, list[str]]` mapping mood labels and feature buckets to descriptor words: e.g. 'Dark' \u2192 ['Dark', 'Shadowed', 'Nocturnal'], 'Intense' \u2192 ['Fierce', 'Intense', 'Relentless'], 'Peak Hour' \u2192 ['Driving', 'Propulsive'], 'Groovy' \u2192 ['Rhythmic', 'Hypnotic'], etc. (at least 15 mood/energy entries). Implement `PlaylistNamer`: `name_cluster(profile: VibeProfile, salience: dict[str, float], library_profiles: list[VibeProfile]) -> str`: pick the top 2 salient feature descriptors (or fall back to dominant_mood + bpm_bucket); call `generate_name(descriptors, noun='Journey'|'Groove'|'Set'|'Wave' based on mood, used_names)`. `name_all_clusters(clusters: list[ClusterResult], features: dict[Path, IntensityFeatures], metadata: dict[Path, TrackMetadata]) -> dict[int, str]`: calls compute_vibe_profile + score_salience for each cluster; ensures no duplicate names (appends 'II'/'III' if collision). (2) In PlaylistsView, after Generate Playlists completes, call `name_all_clusters` and display the returned names as cluster row labels. (3) Make cluster name labels in the cluster sidebar double-click-editable (use `Gtk.EditableLabel` or a popover). (4) Add unit tests.",
-      "acceptance_criteria": "tests/unit/test_playlist_namer.py: name_all_clusters on 3 synthetic clusters returns 3 distinct non-empty strings. Duplicate prevention appends II/III. Cluster sidebar in PlaylistsView shows generated names. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 7,
-      "note": "GitHub issue #104"
+      "description": "Create playchitect/core/features.py. This module provides a single public function used by both the existing playlist_builder.py and the new seed_playlist.py (TASK-06) so there is one source of truth for the 8-D feature vector.\n\nPublic API:\n    build_feature_vector(metadata: TrackMetadata, features: IntensityFeatures) -> np.ndarray | None\n\nImplementation rules:\n- Import FEATURE_NAMES from playchitect.core.weighting. FEATURE_NAMES is already defined there as: ('bpm', 'rms_energy', 'brightness', 'sub_bass', 'kick_energy', 'bass_harmonics', 'percussiveness', 'onset_strength').\n- Return None if metadata.bpm is None or features is None.\n- Return np.array([metadata.bpm, features.rms_energy, features.brightness, features.sub_bass_energy, features.kick_energy, features.bass_harmonics, features.percussiveness, features.onset_strength], dtype=float).copy() — the .copy() ensures the caller cannot mutate the original.\n- Add __all__ = ['build_feature_vector'].\n- Add a one-line module docstring: 'Shared 8-D feature vector construction for clustering and similarity ranking.'\n\nAlso refactor the private _features_to_vector function in playchitect/core/playlist_builder.py to delegate to build_feature_vector rather than duplicating the logic. In playlist_builder.py, add 'from playchitect.core.features import build_feature_vector' at the top imports. Change _features_to_vector to: def _features_to_vector(features: IntensityFeatures) -> np.ndarray | None: return build_feature_vector(TrackMetadata(filepath=Path(''), bpm=None), features) — wait, that won't work because the 7-D vs 8-D difference matters. Actually: _features_to_vector is called with only IntensityFeatures (no BPM), producing a 7-D vector used for centroid distance in existing clusters where the centroid is also 7-D. Do NOT change _features_to_vector or any centroid distances in playlist_builder.py — leave that file's internal logic alone. Only add the import of build_feature_vector to playlist_builder.py's imports section (it will be used in TASK-06, not here). The important thing is that features.py exists and TASK-01's tests pass.\n\nDo NOT modify clustering.py in this task.",
+      "acceptance_criteria": "tests/unit/test_feature_vector.py passes (all 5 test cases green). uv run pytest tests/unit/test_feature_vector.py -o addopts='' -q reports 0 failures. Existing tests in tests/unit/test_playlist_builder.py and tests/unit/test_clustering.py also pass — the refactor broke nothing.",
+      "completed": false,
+      "priority": 2
     },
     {
       "id": "TASK-03",
-      "epic": "GUI Restructure",
-      "title": "four_view_navigation_sidebar",
+      "epic": "Tests — Core",
+      "title": "test_seed_playlist_ranking_and_fill",
       "owner": "ralph",
-      "description": "Replace the current `PlaychitectWindow` layout in playchitect/gui/windows/main_window.py with an `Adw.OverlaySplitView` navigation sidebar containing four views. Steps: (1) Change `PlaychitectWindow` to inherit `Adw.ApplicationWindow` (already does). Replace the existing body with: an `Adw.OverlaySplitView` where sidebar_width_fraction=0.18. (2) Sidebar content: a `Gtk.Box(orientation=VERTICAL)` containing a `Gtk.ListBox` with CSS class `navigation-sidebar`. Add four `Gtk.ListBoxRow` entries, each a `Gtk.Box(HORIZONTAL)` with a `Gtk.Image` (icon-name) + `Gtk.Label`: Library (folder-music-symbolic), Playlists (media-playlist-symbolic), Set Builder (view-list-symbolic), Export (document-send-symbolic). (3) Main content: `Adw.ViewStack` with pages named 'library', 'playlists', 'set-builder', 'export'. Wire `ListBox.row-selected` signal to `stack.set_visible_child_name()`. (4) Header bar: keep existing `Adw.HeaderBar`; remove the old cluster button; add an `Adw.MenuButton` (icon-name=open-menu-symbolic) with a `Gio.Menu` containing: 'Open Folder', separator, 'Preferences', 'Keyboard Shortcuts', 'About Playchitect'. (5) Move the existing scan + cluster logic into a stub 'library' page (Gtk.Label('Library \u2014 coming soon') for now). (6) Add a stub `Adw.PreferencesWindow` opened from the Preferences menu item with one page 'General' and one row 'Library path'. (7) Update all GUI smoke tests in tests/gui/ to target the new widget hierarchy. Do NOT implement the full view content \u2014 that is TASK-04 through TASK-07.",
-      "acceptance_criteria": "tests/gui/: smoke tests pass with updated widget selectors. App launches with four-row sidebar. Clicking each row switches ViewStack child. App menu opens. Preferences window opens with a Library path row. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 3,
-      "note": "GitHub issue #112 (MVP)"
+      "description": "Write tests/unit/test_seed_playlist.py. This covers two internal functions that do not exist yet: rank_by_similarity and fill_to_duration. Both will live in playchitect/core/seed_playlist.py (does not exist yet). Write the tests to import from playchitect.core.seed_playlist — they must fail at import until TASK-06 creates the module.\n\nCopy the make_metadata and make_intensity helpers from tests/unit/test_playlist_builder.py into this file (do NOT import them).\n\nTest class TestRankBySimilarity — tests for rank_by_similarity(seed_vec: np.ndarray, candidates: dict[Path, np.ndarray], *, genre: str | None = None, weight_overrides=None) -> list[tuple[Path, float]]:\n1. test_identical_seed_ranks_zero_distance: Build a seed_vec. Put the same vector as one candidate. Assert the first result is that path and distance is approx 0.0.\n2. test_ordering_is_nearest_first: Create 3 candidates at distances 5.0, 1.0, 3.0 from the seed. Assert the returned order is distance 1.0, 3.0, 5.0.\n3. test_empty_candidates_returns_empty_list: Call with an empty dict. Assert returns [].\n4. test_single_candidate: One candidate. Assert returns a list of length 1.\n5. test_changing_genre_changes_order: With 3 candidates at similar distances, pass genre='techno' vs genre='ambient'. Assert the orderings differ (because genre changes the weight vector applied before distance).\n\nTest class TestFillToDuration — tests for fill_to_duration(ranked: list[tuple[Path, float]], metadata_dict: dict[Path, TrackMetadata], target_secs: float, tolerance: float, seed_path: Path) -> list[Path]:\n1. test_seed_always_included: ranked list does NOT include the seed (it is passed separately as seed_path). The seed should appear in the output even if it would overflow the target.\n2. test_total_duration_within_tolerance: With 20 tracks of 360s each and target_secs=3600 (60 min), tolerance=0.1, assert sum of returned track durations is between 3240 and 3960 seconds.\n3. test_short_library_returns_all: target_secs longer than all tracks combined — returns every track without error.\n4. test_zero_duration_tracks_skipped: Add one track with duration=0.0. Assert it is never in the result.\n5. test_tolerance_boundary_respected: target_secs=600, tolerance=0.0 (no tolerance). Only tracks that fit exactly at or under 600 seconds total are included.\n\nThese tests must FAIL at import until TASK-06 is merged.",
+      "acceptance_criteria": "tests/unit/test_seed_playlist.py collects cleanly (no syntax errors) but all tests fail at import with ModuleNotFoundError because playchitect/core/seed_playlist.py does not exist. File covers: 5 TestRankBySimilarity tests and 5 TestFillToDuration tests.",
+      "completed": false,
+      "priority": 2
     },
     {
       "id": "TASK-04",
-      "epic": "GUI Restructure",
-      "title": "library_view",
+      "epic": "Tests — Core",
+      "title": "test_generate_playlist_from_seed",
       "owner": "ralph",
-      "description": "Implement the Library view. Create playchitect/gui/views/__init__.py and playchitect/gui/views/library_view.py with `LibraryView(Gtk.Box)`. (1) Track list: `Gtk.ColumnView` backed by `Gio.ListStore` of `LibraryTrackModel(GObject.Object)` objects with properties: title (str), artist (str), bpm (float), duration_secs (float), filepath (str), file_format (str). Columns: Title, Artist, BPM (formatted '%.0f'), Duration ('M:SS'), Format. Use `Gtk.SignalListItemFactory` for each column. Wrap in a `Gtk.FilterListModel` (Gtk.CustomFilter) + `Gtk.SortListModel`. (2) Search bar: `Gtk.SearchBar` toggled by a header `Gtk.ToggleButton` (icon: system-search-symbolic). Filter function matches title and artist (case-insensitive). (3) Format chips: a `Gtk.Box` below the header with `Gtk.ToggleButton` chips for All / FLAC / MP3 / OGG / WAV. Connected to the filter. (4) Footer: `Gtk.Label` showing '{n} tracks'. (5) Open Folder button in header (folder-open-symbolic): opens `Gtk.FileDialog` in folder mode, on accept runs `AudioScanner` + `MetadataExtractor` in a `threading.Thread`, emits a `'scan-complete'` GObject signal with the track list, shows `Gtk.Spinner` while scanning. (6) Row selection emits a `'track-selected'` GObject signal with the `LibraryTrackModel`. (7) Register as 'library' page in main_window.py ViewStack. (8) Add GUI smoke test in tests/gui/test_library_view.py. Imports: re-use `AudioScanner` from playchitect/core/audio_scanner.py and `MetadataExtractor` from playchitect/core/metadata_extractor.py.",
-      "acceptance_criteria": "tests/gui/test_library_view.py: LibraryView instantiates without error in mock GTK environment. Format chip filtering works in unit test. Search filter matches on title/artist. 'track-selected' signal is defined. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 3,
-      "note": "GitHub issue #113 (MVP)"
+      "description": "Add a third test class to tests/unit/test_seed_playlist.py: TestGeneratePlaylistFromSeed. This covers the public function generate_playlist_from_seed that will be created in TASK-06.\n\nSignature to test against: generate_playlist_from_seed(seed_path: Path, candidate_features: dict[Path, IntensityFeatures], metadata_dict: dict[Path, TrackMetadata], target_duration_mins: float, *, genre: str | None = None, weight_overrides=None, tolerance: float = 0.1, sequence_mode: str = 'ramp') -> ClusterResult\n\nImport ClusterResult from playchitect.core.clustering.\n\nTests:\n1. test_returns_cluster_result: Call with a small synthetic library (10 tracks × 360s, target 30 min). Assert result is an instance of ClusterResult.\n2. test_seed_included_in_result: The seed_path must appear in result.tracks.\n3. test_duration_within_tolerance: result.total_duration is between target_duration_mins*60*(1-0.1) and target_duration_mins*60*(1+0.1) when library has enough tracks.\n4. test_cluster_result_name_contains_seed_title: result.mood or a string field contains 'Like:' (the auto-name). Use result.genre or check ClusterResult fields — the name is stored in result.genre field as 'Like: <seed_title>' based on metadata title.\n5. test_ramp_and_flat_give_different_order: Call twice with sequence_mode='ramp' and sequence_mode='flat'. Assert the track orderings differ (ramp ascends by energy, flat does not reorder beyond nearest-first).\n6. test_invalid_target_raises_value_error: target_duration_mins=0 raises ValueError.\n7. test_empty_candidates_raises_value_error: candidate_features={} raises ValueError.\n8. test_seed_absent_from_candidates_raises_value_error: seed_path not in candidate_features raises ValueError.\n9. test_result_is_exportable: Pass result to M3UExporter.export_cluster and assert it writes a non-empty .m3u file (use tmp_path fixture). Import M3UExporter from playchitect.core.export.\n\nThese tests must FAIL at import until TASK-06 is merged.",
+      "acceptance_criteria": "TestGeneratePlaylistFromSeed class added to tests/unit/test_seed_playlist.py with 9 tests, all failing at import. No syntax errors. All assertions are specific and deterministic.",
+      "completed": false,
+      "priority": 2
     },
     {
       "id": "TASK-05",
-      "epic": "GUI Restructure",
-      "title": "playlists_view",
+      "epic": "Tests — CLI",
+      "title": "test_cli_playlist_command",
       "owner": "ralph",
-      "description": "Implement the Playlists view. Create playchitect/gui/views/playlists_view.py with `PlaylistsView(Gtk.Box)`. Migrate logic from playchitect/gui/widgets/cluster_view.py and cluster_stats.py. (1) Top toolbar `Gtk.ActionBar`: [Generate Playlists] `Gtk.Button` (primary style), `Gtk.Spinner` (hidden while idle), cluster count `Gtk.Label`. (2) Left cluster sidebar (~250px, `Gtk.Paned` left child): `Gtk.ListBox` of `ClusterRowWidget` \u2014 each row shows cluster index label, track count badge, and a small coloured energy indicator bar. Clicking a row emits `'cluster-selected'` signal. (3) Right content (`Gtk.Paned` right child): `Gtk.ColumnView` for the selected cluster's tracks \u2014 columns: #, Title, Artist, BPM, Intensity. (4) Stats strip below the right pane: reuse `ClusterStats` widget from playchitect/gui/widgets/cluster_stats.py. (5) [Generate Playlists] button handler: call `IntensityAnalyzer.analyze_batch()` then `PlaylistClusterer.cluster_by_features()` in a `threading.Thread`, on completion use `GLib.idle_add` to refresh the cluster sidebar. (6) Register as 'playlists' page in main_window.py. Remove the old split-pane cluster panel from main_window.py once migrated. Add smoke tests in tests/gui/test_playlists_view.py.",
-      "acceptance_criteria": "tests/gui/test_playlists_view.py: PlaylistsView instantiates. cluster-selected signal defined. ClusterStats reused. Existing GUI smoke tests still pass. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 3,
-      "note": "GitHub issue #115 (MVP)"
+      "description": "Write tests/integration/test_cli_playlist.py. This covers the 'playchitect playlist' CLI command that will be created in TASK-07 and TASK-08. Use Click's CliRunner throughout.\n\nImports needed: from click.testing import CliRunner; from playchitect.cli.commands import cli. Use tmp_path fixture from pytest.\n\nHelper: create a small fixture music directory with 5 fake .m3u files using tmp_path. Because the CLI loads real audio files via librosa, use the existing tests/fixtures/ directory pattern if fixture audio exists, otherwise mock IntensityAnalyzer.analyze_batch and MetadataExtractor.extract_batch to return synthetic data (check tests/integration/ for existing patterns).\n\nTests:\n1. test_playlist_help_shows_command: runner.invoke(cli, ['playlist', '--help']). Assert exit_code==0 and '--seed' in output and '--duration' in output.\n2. test_missing_seed_fails: runner.invoke(cli, ['playlist', '--music-dir', str(tmp_path), '--duration', '60']). Assert exit_code != 0 and 'Missing option' in output.\n3. test_missing_music_dir_fails: runner.invoke(cli, ['playlist', '--seed', '/nonexistent.mp3', '--duration', '60']). Assert exit_code != 0.\n4. test_missing_duration_fails: runner.invoke(cli, ['playlist', '--seed', '/nonexistent.mp3', '--music-dir', str(tmp_path)]). Assert exit_code != 0.\n5. test_zero_duration_fails: runner.invoke(cli, ['playlist', '--seed', str(some_path), '--music-dir', str(tmp_path), '--duration', '0']). Assert exit_code != 0 and 'duration' in output.lower().\n6. test_nonexistent_seed_fails: runner.invoke(cli, ['playlist', '--seed', '/does/not/exist.mp3', '--music-dir', str(tmp_path), '--duration', '60']). Assert exit_code != 0.\n7. test_valid_run_creates_m3u (mock-based): Mock MetadataExtractor.extract_batch and IntensityAnalyzer.analyze_batch to return synthetic data for 20 tracks. Provide a real seed file path (one of the 20). Assert exit_code==0 and an .m3u file was created in the output location and contains the seed path.\n8. test_sequence_option_accepted: Include '--sequence ramp' and assert exit_code==0 (or at least not a flag-not-found error).\n\nTests 1–6 must fail at collection (ImportError or 'No such command playlist') until TASK-07 is merged. Tests 7–8 may need mocking infrastructure that you set up now.",
+      "acceptance_criteria": "tests/integration/test_cli_playlist.py exists with 8 tests. Tests 1–6 fail cleanly (no syntax error). Test runner.invoke shows 'No such command' for 'playlist' until TASK-07 is merged, which is expected.",
+      "completed": false,
+      "priority": 2
     },
     {
       "id": "TASK-06",
-      "epic": "GUI Restructure",
-      "title": "export_view",
+      "epic": "Core — Seed playlist engine",
+      "title": "seed_playlist_module",
       "owner": "ralph",
-      "description": "Implement the Export view. Create playchitect/gui/views/export_view.py with `ExportView(Gtk.Box)`. (1) Format radio group: a `Gtk.Box(VERTICAL)` section labelled 'Format'. Six `Gtk.CheckButton` items chained (group=first_button): M3U playlist (enabled, selected by default), CUE sheet (enabled), Rekordbox XML (sensitive=False, tooltip='Coming in a future release'), Traktor NML (sensitive=False), Serato crates (sensitive=False), Mixxx crate (sensitive=False). (2) Playlists selector section: `Gtk.CheckButton` 'All clusters' + `Gtk.CheckButton` 'Selected only' + `Gtk.DropDown` (string list of cluster names, insensitive unless 'Selected only' active). (3) Destination section: `Gtk.Entry` defaulting to `str(Path.home() / 'Music' / 'Playlists')` + `Gtk.Button` 'Browse\u2026' (opens `Gtk.FileDialog` folder mode, updates entry). Persist in `get_config()` under key `export.last_destination`. (4) Action row: `Gtk.Button` 'Export' (suggested-action style) + `Gtk.Button` '\u21ba Sync with Mixxx' (sensitive=False, tooltip='Configure Mixxx database path in Preferences'). Export button handler: run `M3UExporter` or `CUEExporter` from playchitect/core/export.py in a `threading.Thread`; on success show an `Adw.Toast` via `self.get_ancestor(Adw.ToastOverlay)`. (5) Last export status: `Gtk.Label` below actions, updated after export. (6) Register as 'export' page in main_window.py. Add smoke tests in tests/gui/test_export_view.py.",
-      "acceptance_criteria": "tests/gui/test_export_view.py: ExportView instantiates. Format radio group has 6 children, 4 insensitive. Destination entry defaults to ~/Music/Playlists. Export button is sensitive. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 3,
-      "note": "GitHub issue #116 (Milestone 6)"
+      "description": "Create playchitect/core/seed_playlist.py. This is the core engine. It must make all tests in TASK-01, TASK-03, and TASK-04 pass.\n\nPublic API:\n    generate_playlist_from_seed(\n        seed_path: Path,\n        candidate_features: dict[Path, IntensityFeatures],\n        metadata_dict: dict[Path, TrackMetadata],\n        target_duration_mins: float,\n        *,\n        genre: str | None = None,\n        weight_overrides: WeightOverrides | None = None,\n        tolerance: float = 0.1,\n        sequence_mode: str = 'ramp',\n    ) -> ClusterResult\n\nPrivate helpers (used internally and tested via the public function):\n    rank_by_similarity(seed_vec, candidates, *, genre, weight_overrides) -> list[tuple[Path, float]]\n    fill_to_duration(ranked, metadata_dict, target_secs, tolerance, seed_path) -> list[Path]\n\nStep-by-step algorithm for generate_playlist_from_seed:\n\n1. VALIDATE inputs:\n   - Raise ValueError('target_duration_mins must be positive') if target_duration_mins <= 0.\n   - Raise ValueError('candidate_features must not be empty') if not candidate_features.\n   - Raise ValueError('seed_path not found in candidate_features') if seed_path not in candidate_features.\n\n2. BUILD 8-D VECTORS: for each path in candidate_features, call build_feature_vector(metadata_dict[path], candidate_features[path]) from playchitect.core.features. Skip (log warning) paths where build_feature_vector returns None. Store as candidates: dict[Path, np.ndarray].\n\n3. GET SEED VECTOR: seed_vec = candidates[seed_path]. If seed_path not in candidates after step 2, raise ValueError.\n\n4. SCALE + WEIGHT via rank_by_similarity:\n   - Inside rank_by_similarity: build an (N, 8) matrix from all candidate vectors. Fit StandardScaler (from sklearn.preprocessing) on this matrix. Transform the matrix AND the seed vector using the fitted scaler (scaler.transform([[seed_vec]])[0]).\n   - Call weighting.select_weights(X_scaled=scaled_matrix, genre=genre, weight_overrides=weight_overrides) from playchitect.core.weighting. This returns a WeightProfile with a .weights ndarray of shape (8,).\n   - Apply weight_profile.weights: multiply each scaled vector element-wise by weights. Also multiply the scaled seed vector element-wise.\n   - Compute Euclidean distance from the weighted seed vector to each weighted candidate vector: float(np.linalg.norm(weighted_candidate - weighted_seed)).\n   - Return sorted list of (path, distance) tuples, nearest first.\n\n5. FILL TO DURATION via fill_to_duration:\n   - Always prepend seed_path to the result with distance 0.0 before the greedy loop — the seed is always first and always included.\n   - Iterate ranked list. For each path (skipping paths with no metadata duration or duration <= 0), add to selected if cumulative_duration + track_duration <= target_secs * (1 + tolerance). Stop early if cumulative_duration already exceeds target_secs * (1 - tolerance) and tolerance is 0. If target longer than all tracks, return all tracks.\n   - Return list[Path].\n\n6. SEQUENCE the selected tracks using sequence_by_strategy(tracks=selected, features=candidate_features, strategy=sequence_mode, metadata=metadata_dict) from playchitect.core.sequencer. Valid sequence_mode values are: 'ramp', 'build', 'descent', 'alternating', 'bpm_asc', 'bpm_desc'. If sequence_mode not in this set, default to 'ramp' and log a warning. Note: sequence_by_strategy raises ValueError if a track is missing from features — all selected tracks come from candidate_features so this should not happen.\n\n7. COMPUTE stats for ClusterResult:\n   - bpm_values = [metadata_dict[p].bpm for p in sequenced_tracks if metadata_dict.get(p) and metadata_dict[p].bpm]\n   - bpm_mean = float(np.mean(bpm_values)) if bpm_values else 0.0\n   - bpm_std = float(np.std(bpm_values)) if bpm_values else 0.0\n   - total_duration = sum(metadata_dict[p].duration or 0.0 for p in sequenced_tracks)\n   - seed_title: metadata_dict.get(seed_path) and metadata_dict[seed_path].title or seed_path.stem\n   - Store the name in the ClusterResult.genre field as f'Like: {seed_title}' (this is the only free-text label field).\n   - centroid = scaled+weighted seed vector (a np.ndarray of shape (8,)).\n\n8. RETURN ClusterResult(\n       cluster_id='seed',\n       tracks=sequenced_tracks,\n       bpm_mean=bpm_mean,\n       bpm_std=bpm_std,\n       track_count=len(sequenced_tracks),\n       total_duration=total_duration,\n       genre=f'Like: {seed_title}',\n       centroid=centroid,\n   )\n\nImports needed: pathlib.Path, logging, numpy as np, sklearn.preprocessing.StandardScaler, playchitect.core.features.build_feature_vector, playchitect.core.clustering.ClusterResult, playchitect.core.intensity_analyzer.IntensityFeatures, playchitect.core.metadata_extractor.TrackMetadata, playchitect.core.sequencer.sequence_by_strategy, playchitect.core.weighting.select_weights, playchitect.utils.weight_config.WeightOverrides.\n\nAdd __all__ = ['generate_playlist_from_seed'] and a module docstring:\n'Seed-based playlist generation: build a length-targeted playlist of tracks similar to a single seed track.'\n\nDo NOT modify any existing files other than adding the import of build_feature_vector to playlist_builder.py (already done in TASK-02).",
+      "acceptance_criteria": "uv run pytest tests/unit/test_feature_vector.py tests/unit/test_seed_playlist.py -o addopts='' -q — all tests pass. uv run pytest tests/unit/test_playlist_builder.py tests/unit/test_clustering.py -o addopts='' -q — no regressions. Coverage on playchitect/core/seed_playlist.py is ≥85% (check with uv run pytest tests/unit/test_seed_playlist.py --cov=playchitect/core/seed_playlist --cov-report=term-missing -o addopts='').",
+      "completed": false,
+      "priority": 3
     },
     {
       "id": "TASK-07",
-      "epic": "GUI Restructure",
-      "title": "track_preview_panel",
+      "epic": "CLI",
+      "title": "playlist_command_skeleton",
       "owner": "ralph",
-      "description": "Implement the track preview panel. Create playchitect/gui/widgets/track_preview_panel.py with `TrackPreviewPanel(Gtk.Box)`. (1) Cover art: 240\u00d7240 `Gtk.Picture` (content-fit=cover). Extract embedded APIC/METADATA_BLOCK_PICTURE tag using mutagen; save to `~/.cache/playchitect/covers/<md5(filepath).hex>.jpg`; load via `GdkPixbuf.Pixbuf.new_from_file_at_scale(path, 240, 240, True)`. On no art, use `Gtk.Image.new_from_icon_name('audio-x-generic')` placeholder. (2) Metadata labels: `Gtk.Label` for title (large, bold CSS class `title-1`), artist (subtitle style), album + year (caption). (3) Key info row: small pill `Gtk.Label` widgets for BPM, Key (if tagged), Duration, Format \u2014 each with `pill` CSS class. (4) Audio playback: use GStreamer via `gi.repository.Gst`. Create a `playbin` element; `set_state(Gst.State.PLAYING)` on play, `PAUSED` on pause, `NULL` to stop. Controls: [\u23ee prev] [\u25b6/\u23f8] [\u23ed next] `Gtk.Button` widgets \u2014 wired to emit `'prev-track'` / `'next-track'` GObject signals. Seekbar: `Gtk.Scale(HORIZONTAL)` updated every 100ms via `GLib.timeout_add(100, self._update_position)`. Volume: `Gtk.Scale(HORIZONTAL, range 0\u20131.0)`. (5) `load_track(track: LibraryTrackModel) -> None` public method: extracts art, sets labels, resets playback. (6) Wire to `LibraryView`'s `'track-selected'` signal in main_window.py. (7) Panel hidden by default; toggled by `[\u25e8]` `Gtk.ToggleButton` in LibraryView header. Mock GStreamer in tests (set env `GST_PLUGIN_SYSTEM_PATH_1_0=` to disable). Add smoke tests in tests/gui/test_track_preview_panel.py.",
-      "acceptance_criteria": "tests/gui/test_track_preview_panel.py: TrackPreviewPanel instantiates with GStreamer mocked. load_track() sets the title label. Art fallback to generic icon when no APIC tag. GObject signals prev-track and next-track are defined. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 3,
-      "note": "GitHub issue #114"
+      "description": "Add the 'playlist' command skeleton to playchitect/cli/commands.py. This task makes tests 1–6 from TASK-05 pass. Do NOT wire in the generation logic yet (that is TASK-08).\n\nAdd this command after the existing 'info' command:\n\n@cli.command()\n@click.option('--seed', required=True, type=click.Path(exists=True, path_type=Path), help='Path to the seed track.')\n@click.option('--music-dir', 'music_dir', required=True, type=click.Path(exists=True, file_okay=False, path_type=Path), help='Music library directory to search.')\n@click.option('--duration', 'target_duration', required=True, type=float, help='Target playlist length in minutes.')\n@click.option('--output', '-o', type=click.Path(path_type=Path), default=None, help='Output playlist file path (.m3u or .cue). Defaults to <music-dir>/Like_<seed_stem>.m3u.')\n@click.option('--sequence', 'sequence_mode', type=click.Choice(['ramp', 'build', 'descent', 'alternating', 'bpm_asc', 'bpm_desc']), default='ramp', show_default=True, help='Energy sequencing strategy.')\n@click.option('--genre', type=str, default=None, help='Genre hint for feature weighting (techno, house, ambient, dnb).')\ndef playlist(\n    seed: Path,\n    music_dir: Path,\n    target_duration: float,\n    output: Path | None,\n    sequence_mode: str,\n    genre: str | None,\n) -> None:\n    'Generate a playlist of similar tracks based on a seed track.'\n    if target_duration <= 0:\n        click.echo('Error: --duration must be greater than 0.', err=True)\n        raise SystemExit(1)\n    click.echo('Playlist generation not yet implemented.')\n\nNote: click.Path(exists=True) already validates that --seed exists, so test_nonexistent_seed_fails will be handled by Click automatically. The explicit duration > 0 check is needed because Click allows any float.\n\nDo NOT add any imports beyond what is already at the top of commands.py.",
+      "acceptance_criteria": "uv run pytest tests/integration/test_cli_playlist.py -k 'test_playlist_help or test_missing or test_zero or test_nonexistent' -o addopts='' -q — all 6 validation tests pass. uv run playchitect playlist --help shows all 6 options. Existing scan/info/import-rekordbox commands unaffected.",
+      "completed": false,
+      "priority": 4
     },
     {
       "id": "TASK-08",
-      "epic": "GUI Restructure",
-      "title": "playlist_size_unit_controls",
+      "epic": "CLI",
+      "title": "playlist_command_wiring",
       "owner": "ralph",
-      "description": "Add playlist size controls to PlaylistsView (TASK-05 must be done first). In the PlaylistsView toolbar (`Gtk.ActionBar`): (1) Add `Gtk.SpinButton` labelled 'Tracks per playlist' (range 5\u2013200, step 1, value 20, snap-to-ticks). (2) Add `Gtk.DropDown` with model ['tracks', 'minutes']. When 'minutes' selected, swap the SpinButton range to 30\u2013240, step 5, value 60. (3) Add `Gtk.SpinButton` labelled 'Playlists' (range 0\u201320, step 1, value 0; 0 means auto from elbow/silhouette). (4) In PlaylistClusterer (playchitect/core/clustering.py), the `scan` CLI command already passes `target_tracks` and `target_duration` \u2014 confirm the `cluster_by_features()` method accepts these; add `n_playlists: int | None = None` param that overrides auto-K selection when > 0. (5) Wire all three controls to the Generate Playlists button handler in PlaylistsView. Add unit tests in tests/unit/test_clustering.py for the new n_playlists param.",
-      "acceptance_criteria": "tests/unit/test_clustering.py: cluster_by_features with n_playlists=3 returns exactly 3 clusters. PlaylistsView smoke test shows SpinButton and DropDown in toolbar. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 3,
-      "note": "GitHub issue #103 (MVP)"
+      "description": "Complete the body of the 'playlist' command in playchitect/cli/commands.py. Replace the stub body ('Playlist generation not yet implemented.') with the real implementation. This task makes tests 7–8 from TASK-05 pass.\n\nImplementation steps inside the playlist() function body (after the duration > 0 validation):\n\n1. SCAN library:\n   scanner = AudioScanner()\n   audio_files = scanner.scan_directory(music_dir)\n   if not audio_files:\n       click.echo(f'No audio files found in {music_dir}', err=True)\n       raise SystemExit(1)\n\n2. EXTRACT METADATA:\n   click.echo(f'Analysing {len(audio_files)} tracks...')\n   extractor = MetadataExtractor()\n   metadata_dict = extractor.extract_batch(audio_files)\n\n3. ANALYSE INTENSITY (uses JSON cache automatically):\n   from playchitect.core.intensity_analyzer import IntensityAnalyzer\n   analyzer = IntensityAnalyzer()\n   intensity_dict = analyzer.analyze_batch(list(metadata_dict.keys()))\n\n4. GENERATE PLAYLIST:\n   from playchitect.core.seed_playlist import generate_playlist_from_seed\n   try:\n       result = generate_playlist_from_seed(\n           seed_path=seed,\n           candidate_features=intensity_dict,\n           metadata_dict=metadata_dict,\n           target_duration_mins=target_duration,\n           genre=genre,\n           sequence_mode=sequence_mode,\n       )\n   except ValueError as e:\n       click.echo(f'Error: {e}', err=True)\n       raise SystemExit(1)\n\n5. DETERMINE output path:\n   if output is None:\n       output = music_dir / f'Like_{seed.stem}.m3u'\n   output.parent.mkdir(parents=True, exist_ok=True)\n\n6. EXPORT:\n   if output.suffix.lower() == '.cue':\n       from playchitect.core.export import CUEExporter\n       exporter = CUEExporter()\n       exporter.export_cluster(result, output, metadata_dict)\n   else:\n       from playchitect.core.export import M3UExporter\n       exporter = M3UExporter()\n       exporter.export_cluster(result, output, metadata_dict)\n\n7. PRINT SUMMARY:\n   duration_mins = result.total_duration / 60\n   click.echo(f'Created playlist: {output}')\n   click.echo(f'  {result.track_count} tracks — {duration_mins:.1f} min')\n   click.echo(f'  Sequence: {sequence_mode}')\n\nAdd imports at the top of commands.py (in the existing imports block): from playchitect.core.intensity_analyzer import IntensityAnalyzer; from playchitect.core.seed_playlist import generate_playlist_from_seed. The M3UExporter and CUEExporter are already imported in the file.\n\nDo NOT change any existing command (scan, info, import-rekordbox).",
+      "acceptance_criteria": "uv run pytest tests/integration/test_cli_playlist.py -o addopts='' -q — all 8 tests pass. Manual smoke test: uv run playchitect playlist --seed '<real_track>' --music-dir ~/Music --duration 90 creates Like_<seed_stem>.m3u with ~90 min of tracks. The first entry in the M3U is the seed track.",
+      "completed": false,
+      "priority": 5
+    },
+    {
+      "id": "TASK-09",
+      "epic": "Tests — GUI",
+      "title": "test_library_seed_action_ui",
+      "owner": "ralph",
+      "description": "Write tests/gui/test_library_seed_action.py. This covers UI that will be added to LibraryView in TASK-10. Use the same mock harness as existing tests in tests/gui/ — the conftest.py in that directory mocks all gi.repository imports, so tests run without a display.\n\nPattern to follow: look at tests/gui/test_library_view.py for how to import LibraryView and write tests without a real GTK display. The mock harness makes Gtk/Adw calls no-ops.\n\nTests (class TestSeedPlaylistAction):\n\n1. test_make_playlist_button_exists: Import LibraryView. Instantiate it. Assert hasattr(view, '_make_playlist_btn') — this is the header toolbar button that will be added in TASK-10.\n\n2. test_button_disabled_with_no_selection: Instantiate LibraryView. Before any selection, call view._on_selection_changed(None, 0, 0) (simulating no selection). Assert view._make_playlist_btn.get_sensitive() returns False (or the mock records set_sensitive(False) was called).\n\n3. test_button_enabled_with_one_selection: Simulate one track selected: set view._selection to a mock whose get_selected() returns 0 (a valid index). Call view._on_selection_changed(None, 0, 1). Assert view._make_playlist_btn.get_sensitive() returns True.\n\n4. test_dialog_opens_on_click: Patch the dialog class that will be created (SeedPlaylistDialog). Call view._on_make_playlist_clicked(None). Assert the dialog's present() method was called.\n\n5. test_signal_make_playlist_seed_exists: Assert 'make-playlist-seed' in LibraryView.__gsignals__. This is the signal LibraryView emits with a (seed_path: str, duration_mins: float, sequence_mode: str) payload when the user confirms the dialog.\n\nThese tests must FAIL (AttributeError or KeyError) until TASK-10 adds the button and signal.",
+      "acceptance_criteria": "tests/gui/test_library_seed_action.py exists with 5 tests in TestSeedPlaylistAction. Tests fail with AttributeError (not syntax errors) because the attributes do not exist yet. File imports successfully using the mock harness.",
+      "completed": false,
+      "priority": 4
     },
     {
       "id": "TASK-10",
-      "epic": "Advanced Audio Analysis",
-      "title": "harmonic_mixing_gui_controls",
+      "epic": "GUI — Library action",
+      "title": "library_view_make_playlist_button_and_dialog",
       "owner": "ralph",
-      "description": "Add harmonic mixing controls to PlaylistsView (requires TASK-09 and TASK-05). (1) In PlaylistsView toolbar, add a `Gtk.Box` with a `Gtk.Label('Harmonic mixing')` and `Gtk.Switch`. (2) Add a 'Key' column to the Playlists track ColumnView showing `camelot_key` from IntensityFeatures. (3) Add a compatibility dot column: a `Gtk.DrawingArea` (16\u00d716) drawn green/amber/red based on `harmonic_compatibility(this_track.camelot_key, prev_track.camelot_key)` \u2014 green=compatible, amber=same number different letter, red=incompatible. (4) In playchitect/core/sequencer.py, inspect the existing `Sequencer` class; add `sequence_harmonic(tracks: list[Path], features: dict[Path, IntensityFeatures]) -> list[Path]` that uses a greedy nearest-Camelot-neighbour approach: start from the track with highest energy, repeatedly pick the next track with the highest `harmonic_compatibility` score (break ties by energy proximity). (5) When the switch is on, call `sequence_harmonic` instead of the default energy ramp in PlaylistsView. Add unit tests for `sequence_harmonic`.",
-      "acceptance_criteria": "tests/unit/test_sequencer.py: sequence_harmonic on 4 tracks with known keys produces a sequence where adjacent pairs maximise compatibility. PlaylistsView smoke test shows switch and Key column. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 4,
-      "note": "GitHub issue #37"
+      "description": "Modify playchitect/gui/views/library_view.py to add the 'Make playlist like this…' action.\n\nChanges required:\n\n1. ADD SIGNAL to LibraryView.__gsignals__ (inside the existing dict):\n   'make-playlist-seed': (GObject.SignalFlags.RUN_FIRST, None, (str, float, str))\n   The three payload values are: seed_filepath (str), target_duration_mins (float), sequence_mode (str).\n\n2. ADD BUTTON in _build_toolbar(). After the existing self._preview_toggle button and before toolbar.append(self._preview_chip), insert:\n   self._make_playlist_btn = Gtk.Button()\n   self._make_playlist_btn.set_icon_name('media-playlist-repeat-symbolic')\n   self._make_playlist_btn.set_tooltip_text('Make playlist like this track…')\n   self._make_playlist_btn.set_sensitive(False)  # disabled until a track is selected\n   self._make_playlist_btn.connect('clicked', self._on_make_playlist_clicked)\n   toolbar.append(self._make_playlist_btn)\n\n3. UPDATE _on_selection_changed to enable/disable the button. This method already exists. Add at the end of it:\n   selected = self._selection.get_selected()\n   has_selection = selected != Gtk.INVALID_LIST_POSITION\n   self._make_playlist_btn.set_sensitive(has_selection)\n\n4. ADD DIALOG CLASS above LibraryView (after the import block and before the _setup_label function):\n   class SeedPlaylistDialog(Adw.MessageDialog):\n       def __init__(self, parent: Gtk.Widget) -> None:\n           super().__init__()\n           self.set_transient_for(parent.get_root())\n           self.set_heading('Make Playlist Like This…')\n           self.set_body('Choose target length and sequencing strategy.')\n           # Duration spin button\n           content_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)\n           content_box.set_margin_top(12)\n           content_box.set_margin_bottom(12)\n           content_box.set_margin_start(24)\n           content_box.set_margin_end(24)\n           # Duration row\n           dur_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)\n           dur_label = Gtk.Label(label='Target length (minutes):')\n           dur_label.set_hexpand(True)\n           dur_label.set_xalign(0.0)\n           self._duration_spin = Gtk.SpinButton()\n           self._duration_spin.set_range(10, 360)\n           self._duration_spin.set_increments(5, 30)\n           self._duration_spin.set_value(90)\n           self._duration_spin.set_snap_to_ticks(True)\n           self._duration_spin.set_numeric(True)\n           dur_box.append(dur_label)\n           dur_box.append(self._duration_spin)\n           content_box.append(dur_box)\n           # Sequence row\n           seq_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)\n           seq_label = Gtk.Label(label='Sequence:')\n           seq_label.set_hexpand(True)\n           seq_label.set_xalign(0.0)\n           self._sequence_dropdown = Gtk.DropDown.new_from_strings(['ramp', 'build', 'descent', 'alternating', 'bpm_asc', 'bpm_desc'])\n           self._sequence_dropdown.set_selected(0)\n           seq_box.append(seq_label)\n           seq_box.append(self._sequence_dropdown)\n           content_box.append(seq_box)\n           self.set_extra_child(content_box)\n           self.add_response('cancel', 'Cancel')\n           self.add_response('generate', 'Generate')\n           self.set_response_appearance('generate', Adw.ResponseAppearance.SUGGESTED)\n           self.set_default_response('generate')\n           self.set_close_response('cancel')\n       def get_duration_mins(self) -> float:\n           return self._duration_spin.get_value()\n       def get_sequence_mode(self) -> str:\n           seq_options = ['ramp', 'build', 'descent', 'alternating', 'bpm_asc', 'bpm_desc']\n           return seq_options[self._sequence_dropdown.get_selected()]\n\n5. ADD HANDLER _on_make_playlist_clicked:\n   def _on_make_playlist_clicked(self, _btn: Gtk.Button) -> None:\n       selected = self._selection.get_selected()\n       if selected == Gtk.INVALID_LIST_POSITION:\n           return\n       item = self._selection.get_item(selected)\n       if not isinstance(item, LibraryTrackModel):\n           return\n       dialog = SeedPlaylistDialog(self)\n       def _on_response(dlg: SeedPlaylistDialog, response: str) -> None:\n           if response == 'generate':\n               self.emit('make-playlist-seed', item.filepath, dlg.get_duration_mins(), dlg.get_sequence_mode())\n           dlg.destroy()\n       dialog.connect('response', _on_response)\n       dialog.present()\n\nAdd 'Adw' to the existing gi.repository import at the top of the file if it is not already there.",
+      "acceptance_criteria": "uv run pytest tests/gui/test_library_seed_action.py -o addopts='' -q — all 5 tests pass. uv run pytest tests/gui/ -o addopts='' -q — no regressions. uv run playchitect-gui launches without errors; with a track selected the button is enabled; clicking it opens a dialog with a spin button and dropdown.",
+      "completed": false,
+      "priority": 5
+    },
+    {
+      "id": "TASK-11",
+      "epic": "Tests — GUI",
+      "title": "test_library_seed_generation_wiring",
+      "owner": "ralph",
+      "description": "Add a second test class TestSeedPlaylistGeneration to tests/gui/test_library_seed_action.py. This covers the main_window signal wiring added in TASK-12.\n\nThese tests should patch generate_playlist_from_seed where it is imported in the main_window module: 'playchitect.gui.windows.main_window.generate_playlist_from_seed'.\n\nTests:\n1. test_main_window_connects_make_playlist_seed_signal: Instantiate MainWindow (using the mock harness). Assert _library_view is connected to the 'make-playlist-seed' signal by checking the handler list or by emitting the signal and verifying _on_make_playlist_seed is called.\n2. test_generation_runs_in_background_thread: Emit 'make-playlist-seed' on library_view with synthetic args. Assert that generate_playlist_from_seed is called (mock) and that the call happens in a daemon thread (not the main thread). Use threading.current_thread() capture inside the mock.\n3. test_completed_result_calls_load_clusters: Set up a mock ClusterResult return value. After the background thread finishes (join it), assert _playlists_view.load_clusters was called with the result.\n4. test_error_shows_toast: Patch generate_playlist_from_seed to raise ValueError('test error'). Emit signal. After thread joins, assert Adw.Toast is created and added to overlay (or _show_error_toast is called — check MainWindow for the existing toast pattern).\n5. test_view_switches_to_playlists: After successful generation, assert _view_stack.set_visible_child_name('playlists') was called.\n\nThese tests must FAIL (AttributeError) until TASK-12 adds the wiring.",
+      "acceptance_criteria": "TestSeedPlaylistGeneration class added to tests/gui/test_library_seed_action.py with 5 tests. All 5 fail with AttributeError (missing handler method) until TASK-12. No syntax errors.",
+      "completed": false,
+      "priority": 5
     },
     {
       "id": "TASK-12",
-      "epic": "Advanced Audio Analysis",
-      "title": "energy_flow_gui_controls",
+      "epic": "GUI — Generation wiring",
+      "title": "main_window_seed_generation_wiring",
       "owner": "ralph",
-      "description": "Add energy flow sort controls to PlaylistsView (requires TASK-11 and TASK-05). (1) Add 'Gradient' and 'Drops/min' columns to the PlaylistsView track ColumnView: Gradient shows a \u2191/\u2193/\u2192 icon based on sign of `energy_gradient`; Drops/min shows `drop_density` formatted as a float. (2) Add a `Gtk.DropDown` labelled 'Sort by' to the PlaylistsView toolbar with options: 'Energy ramp (default)', 'Build to peak', 'Gradual descent', 'Alternating'. (3) In playchitect/core/sequencer.py, add `sequence_by_strategy(tracks: list[Path], features: dict[Path, IntensityFeatures], strategy: str) -> list[Path]` with strategies: 'ramp' (existing ramp sort by rms_energy ascending), 'build' (sort by energy_gradient descending so rising tracks first), 'descent' (sort by rms_energy descending), 'alternating' (interleave high/low energy). (4) Wire the DropDown selection to call `sequence_by_strategy` in the Generate Playlists handler. Add unit tests for each strategy.",
-      "acceptance_criteria": "tests/unit/test_sequencer.py: each of the four strategies produces a different ordering on 6 synthetic tracks. PlaylistsView smoke test shows Sort DropDown with 4 options. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 4,
-      "note": "GitHub issue #39"
+      "description": "Modify playchitect/gui/windows/main_window.py to handle the 'make-playlist-seed' signal from LibraryView and run generate_playlist_from_seed in a background thread.\n\nChanges required:\n\n1. ADD IMPORT at the top of main_window.py (in the existing imports block):\n   from playchitect.core.seed_playlist import generate_playlist_from_seed\n\n2. CONNECT SIGNAL in _build_view_stack() (this method builds the LibraryView). After the existing self._library_view.connect('preview-toggled', ...) line, add:\n   self._library_view.connect('make-playlist-seed', self._on_make_playlist_seed)\n\n3. ADD HANDLER _on_make_playlist_seed:\n   def _on_make_playlist_seed(\n       self,\n       _view: LibraryView,\n       seed_filepath: str,\n       duration_mins: float,\n       sequence_mode: str,\n   ) -> None:\n       if not self._intensity_map:\n           self._show_error_toast('Analyse your library first (Playlists → Generate).')\n           return\n       seed_path = Path(seed_filepath)\n       self._spinner.start()\n       self.set_title('Playchitect — generating playlist…')\n       threading.Thread(\n           target=self._seed_playlist_worker,\n           args=(seed_path, duration_mins, sequence_mode),\n           daemon=True,\n       ).start()\n\n4. ADD WORKER _seed_playlist_worker:\n   def _seed_playlist_worker(\n       self,\n       seed_path: Path,\n       duration_mins: float,\n       sequence_mode: str,\n   ) -> None:\n       try:\n           result = generate_playlist_from_seed(\n               seed_path=seed_path,\n               candidate_features=self._intensity_map,\n               metadata_dict=self._metadata_map,\n               target_duration_mins=duration_mins,\n               sequence_mode=sequence_mode,\n           )\n           GLib.idle_add(self._on_seed_playlist_complete, result)\n       except Exception as exc:\n           logger.exception('Seed playlist generation failed')\n           GLib.idle_add(self._on_seed_playlist_error, str(exc))\n\n5. ADD COMPLETION HANDLER _on_seed_playlist_complete:\n   def _on_seed_playlist_complete(self, result: ClusterResult) -> bool:\n       self._spinner.stop()\n       self.set_title(self._track_title)\n       self._playlists_view.load_clusters([result])\n       self._view_stack.set_visible_child_name('playlists')\n       return False\n\n6. ADD ERROR HANDLER _on_seed_playlist_error:\n   def _on_seed_playlist_error(self, message: str) -> bool:\n       self._spinner.stop()\n       self.set_title(self._track_title)\n       self._show_error_toast(f'Playlist generation failed: {message}')\n       return False\n\n7. CHECK _show_error_toast exists: grep for it in main_window.py. If it does not exist, add:\n   def _show_error_toast(self, message: str) -> None:\n       toast = Adw.Toast.new(message)\n       toast.set_timeout(4)\n       if hasattr(self, '_toast_overlay'):\n           self._toast_overlay.add_toast(toast)\n       else:\n           logger.warning('Toast overlay not available: %s', message)\n\n8. ADD ClusterResult import if not already present:\n   from playchitect.core.clustering import ClusterResult\n\nDo NOT change the existing _start_scan, _scan_worker, or any other scan/cluster workflow.",
+      "acceptance_criteria": "uv run pytest tests/gui/test_library_seed_action.py -o addopts='' -q — all 10 tests (5 from TASK-09 + 5 from TASK-11) pass. uv run pytest tests/gui/ -o addopts='' -q — no regressions. Manual: launch playchitect-gui, scan a folder, select a track, click the button, fill in 90 min, click Generate — a playlist appears in the Playlists view and the app switches to that view automatically.",
+      "completed": false,
+      "priority": 6
+    },
+    {
+      "id": "TASK-13",
+      "epic": "Documentation",
+      "title": "fix_status_and_roadmap_docs",
+      "owner": "ralph",
+      "description": "Fix two misleading project documents.\n\n1. Overwrite STATUS.md in the project root (replace entire contents):\n\n# Playchitect\n**Status:** active\n**Priority:** high\n**Progress:** ~80%\n**Last updated:** 2026-06-15\n**Repo:** `~/Programming/personal/playchitect`\n\n## What it does\nSmart DJ Playlist Manager. Transforms library management from rigid BPM grouping to\nintelligent multi-dimensional K-means clustering (BPM + 7 intensity features).\nGenerates playlists that feel coherent — not just mathematically similar.\n\n## Why it matters\nPersonal DJ tooling for creating sets that sound right, not just look right on paper.\n\n## Next actions\n- [ ] Merge seed-playlist engine (TASK-06) — `playchitect playlist --seed <track> --duration 90`\n- [ ] Merge CLI playlist command (TASK-07, TASK-08)\n- [ ] Merge GUI Library view 'Make playlist like this…' action (TASK-10, TASK-12)\n- [ ] Update VitePress user guide with new feature\n\n## Notes\nMilestones 1–5 complete. Milestone 6 packaging (Flatpak) in progress.\nGUI (Library / Playlists / Set Builder / Export views), energy arc, chapter\ngenerator, harmonic mixing, Rekordbox import, Mixxx sync all merged.\nTracking issue for current feature work: #219.\n\n2. In docs/planning/ROADMAP.md, find the Milestone 7 section (currently marked '📅 Planned') and change its status marker in the table at the top from '📅 Planned' to '🚧 In progress'. Also find the paragraph under '## 📅 Milestone 7' and change the heading to '## 🚧 Milestone 7 — Advanced Set Architecture (In Progress)'. Add a new bullet under the GUI Architecture items: '- **Seed playlist**: generate_playlist_from_seed engine (#219) — 🚧'.\n\nDo NOT touch any other docs files.",
+      "acceptance_criteria": "STATUS.md content matches the template above (correct description, status active, ~80% progress). docs/planning/ROADMAP.md Milestone 7 row in the table shows 🚧 In progress. uv run pre-commit run --all-files passes (ruff does not lint .md files, but the hooks should still pass).",
+      "completed": false,
+      "priority": 7
     },
     {
       "id": "TASK-14",
-      "epic": "Advanced Audio Analysis",
-      "title": "timbre_texture_gui_controls",
+      "epic": "Documentation",
+      "title": "cli_reference_playlist_command",
       "owner": "ralph",
-      "description": "Add timbre controls to PlaylistsView (requires TASK-13 and TASK-05). (1) Add a 'Texture' column to the PlaylistsView track ColumnView: a `Gtk.Label` showing 'Tonal' if spectral_flatness < 0.3, 'Mixed' if 0.3\u20130.6, 'Noisy' if > 0.6. (2) Add a 'Timbre similarity' `Gtk.Scale` (HORIZONTAL, range 0.0\u20131.0, value 0.0) in the PlaylistsView toolbar below the existing controls. (3) When value > 0, before clustering, multiply `mfcc_variance` and `spectral_flatness` into the feature weights: pass a `WeightOverrides` (from TASK-01) where `brightness` (proxy for timbre) gets weight multiplied by `(1 + slider_value * 2)`. Apply via `PlaylistClusterer`'s `weight_overrides` param. (4) Add smoke test asserting the Scale widget exists in PlaylistsView.",
-      "acceptance_criteria": "tests/gui/test_playlists_view.py: PlaylistsView has a Gtk.Scale child. Texture column renders 'Tonal'/'Mixed'/'Noisy'. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 4,
-      "note": "GitHub issue #41"
-    },
-    {
-      "id": "TASK-16",
-      "epic": "Advanced Audio Analysis",
-      "title": "structural_gui_controls",
-      "owner": "ralph",
-      "description": "Add structural controls to PlaylistsView (requires TASK-15 and TASK-05). (1) Add a 'Vocals' filter row in the PlaylistsView toolbar: three `Gtk.ToggleButton` chips 'Any' (default), 'Instrumental' (vocal_presence < 0.3), 'Vocal' (vocal_presence > 0.6). Active chip filters the track list before clustering. (2) Add 'Intro' column to PlaylistsView ColumnView showing `intro_length_secs` formatted as 'Xs'. (3) Add a 'Sort by intro' option to the Sort DropDown (from TASK-12): 'Short intro first' (ascending intro_length_secs), 'Long intro first' (descending). (4) Wire vocal filter to reduce the input track list in the Generate Playlists handler by filtering on vocal_presence before passing to PlaylistClusterer. Add unit tests for the vocal filter logic.",
-      "acceptance_criteria": "tests/unit/: vocal filter correctly partitions tracks by vocal_presence threshold. PlaylistsView smoke test shows the vocal chip row and Intro column. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 4,
-      "note": "GitHub issue #43"
-    },
-    {
-      "id": "TASK-19",
-      "epic": "Advanced Audio Analysis",
-      "title": "energy_arc_visualization",
-      "owner": "ralph",
-      "description": "Implement the energy arc sparkline above the cluster sidebar in PlaylistsView (requires TASK-18 and TASK-05). Create playchitect/gui/widgets/energy_arc_widget.py with `EnergyArcWidget(Gtk.DrawingArea)`. (1) Constructor accepts nothing; expose `update_clusters(clusters: list[ClusterResult]) -> None`. (2) In the `draw` signal handler (connected via `self.set_draw_func`), given a list of (name, mean_rms) pairs: compute x positions evenly spaced; compute y positions from mean_rms normalised 0\u20131 relative to min/max; draw using `cairo.Context`: a filled polygon under the curve (RGBA with 30% alpha), a stroke over the top, and small circle dots at each data point. Colour: use a single `#6B9BDF` blue tone. (3) Minimum height 80px, set via `self.set_size_request(-1, 80)`. (4) In PlaylistsView, place `EnergyArcWidget` above the cluster `Gtk.ListBox`. Call `update_clusters()` after each Generate Playlists completion. (5) Add smoke test asserting `EnergyArcWidget` exists as a child of PlaylistsView.",
-      "acceptance_criteria": "tests/gui/test_playlists_view.py: PlaylistsView contains an EnergyArcWidget child. update_clusters() with a list of 4 ClusterResults does not raise. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 4,
-      "note": "GitHub issue #85"
-    },
-    {
-      "id": "TASK-21",
-      "epic": "Interactive Set Building",
-      "title": "energy_blocks",
-      "owner": "ralph",
-      "description": "Implement Energy Blocks in the Set Builder view (requires TASK-03 stub). (1) Create playchitect/core/energy_blocks.py. Define `EnergyBlock(id: str, name: str, target_duration_min: float, energy_min: float, energy_max: float, cluster_ids: list[int])` dataclass. Implement `suggest_blocks(clusters: list[ClusterResult], features: dict[Path, IntensityFeatures]) -> list[EnergyBlock]`: sort clusters by mean rms_energy; divide into 4\u20135 named groups: 'Warm-up' (lowest 20%), 'Build' (20\u201350%), 'Peak' (50\u201380%), 'Sustain' (80\u201395%), 'Wind Down' (top or bottom based on arc); set target_duration_min proportional to track count; compute energy_min/max from the cluster range. (2) Create playchitect/gui/views/set_builder_view.py with `SetBuilderView(Gtk.Box)`. Top strip: `Gtk.Box(HORIZONTAL)` of `EnergyBlockCard` widgets \u2014 each a `Gtk.Frame` with name label, duration badge, energy range badge. Below: `Gtk.ColumnView` showing tracks in the selected block. [+ Add Block] `Gtk.Button` appends a new 'Custom' block. (3) Register as 'set-builder' page in main_window.py. (4) Add unit tests for suggest_blocks.",
-      "acceptance_criteria": "tests/unit/test_energy_blocks.py: suggest_blocks on 10 clusters returns 4\u20135 blocks covering all clusters. Energy ranges are non-overlapping. SetBuilderView smoke test instantiates. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 5,
-      "note": "GitHub issue #99"
-    },
-    {
-      "id": "TASK-23",
-      "epic": "Interactive Set Building",
-      "title": "interactive_set_builder_workspace",
-      "owner": "ralph",
-      "description": "Implement the full Interactive Set Builder Workspace in SetBuilderView (requires TASK-21, TASK-22). (1) Timeline lane: a `Gtk.Box(HORIZONTAL, spacing=4)` inside a `Gtk.ScrolledWindow(HORIZONTAL)`. Each track in the set is represented by a `TrackCard(Gtk.Frame)` widget showing: 2-char sequence number, title (truncated), BPM, a coloured energy mini-bar, and a transition indicator dot (green/amber/red via compatibility_score with next track). Drag-and-drop reorder: use `Gtk.DragSource` + `Gtk.DropTarget` with `GdkContentProvider` carrying the track index. On drop, swap positions and recalculate transition indicators. (2) Left browser panel: a compact `Gtk.ColumnView` showing all library tracks (Title, Artist, BPM) \u2014 double-click adds to timeline. Filter by energy block (chips matching EnergyBlock names). (3) [Auto-fill] button: from the last track in the timeline, call `next_track_suggestions` greedily (add best candidate not already in set, repeat until timeline has 20 tracks or no candidates remain). (4) [Export Set] button: write the timeline order as an M3U file using `M3UExporter`. (5) Footer `Gtk.StatusBar`: total duration (sum of track durations), mean BPM, mean rms_energy. Add smoke tests.",
-      "acceptance_criteria": "tests/gui/test_set_builder_view.py: SetBuilderView instantiates. TrackCard renders with title and BPM. Auto-fill adds tracks. Export Set button is present. Footer labels exist. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 5,
-      "note": "GitHub issue #101 (MVP)"
-    },
-    {
-      "id": "TASK-24",
-      "epic": "DJ Ecosystem Integration",
-      "title": "specialized_export_formats",
-      "owner": "ralph",
-      "description": "Implement Rekordbox XML and Traktor NML export. (1) Create playchitect/core/exporters/__init__.py and playchitect/core/exporters/rekordbox_xml.py. Implement `RekordboxXMLExporter(output_dir: Path)` with `export_cluster(cluster: ClusterResult, cluster_index: int, metadata_dict: dict[Path, TrackMetadata], features_dict: dict[Path, IntensityFeatures]) -> Path`. Output: a Rekordbox 6-compatible XML file. Structure: `<DJ_PLAYLISTS Version='1.0.0'><COLLECTION>...<TRACK>...</TRACK></COLLECTION><PLAYLISTS><NODE Type='0' Name='ROOT'><NODE Type='1' Name='{cluster_name}'><TRACK Key='{id}'/>...</NODE></NODE></PLAYLISTS></DJ_PLAYLISTS>`. Each TRACK has attrs: `TrackID` (int), `Name` (title), `Artist`, `TotalTime` (int seconds), `AverageBpm` (2dp), `Tonality` (camelot_key or empty), `Location` (`file://localhost` + absolute path). Use `xml.etree.ElementTree`. (2) Create playchitect/core/exporters/traktor_nml.py. Implement `TraktorNMLExporter(output_dir: Path)` producing a Traktor 3 NML file: `<NML Version='19'><COLLECTION ENTRIES='{n}'>...<ENTRY>...</ENTRY></COLLECTION><PLAYLISTS><NODE TYPE='FOLDER' NAME='$ROOT'><SUBNODES COUNT='1'><NODE TYPE='PLAYLIST' NAME='{name}'><PLAYLIST ENTRIES='{n}' TYPE='LIST'><ENTRY><PRIMARYKEY TYPE='TRACK' KEY='{path}'/></ENTRY>...</PLAYLIST></NODE></SUBNODES></NODE></PLAYLISTS></NML>`. (3) Enable Rekordbox XML and Traktor NML radio buttons in ExportView (TASK-06) \u2014 change `sensitive=False` to `sensitive=True` for those two. Wire ExportView export handler to call the appropriate exporter. (4) Add unit tests in tests/unit/test_exporters.py using a 2-track ClusterResult fixture.",
-      "acceptance_criteria": "tests/unit/test_exporters.py: RekordboxXMLExporter writes a file parseable by ElementTree with a COLLECTION node containing TRACK elements. TraktorNMLExporter writes a file with COLLECTION and PLAYLISTS nodes. Both radio buttons are now enabled in ExportView. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 6,
-      "note": "GitHub issue #78"
-    },
-    {
-      "id": "TASK-25",
-      "epic": "DJ Ecosystem Integration",
-      "title": "mixxx_bidirectional_sync",
-      "owner": "ralph",
-      "description": "Implement Mixxx bidirectional sync (requires TASK-06 for ExportView sync button). (1) Create playchitect/core/exporters/mixxx_sync.py. Implement: `read_mixxx_library(db_path: Path) -> list[dict]` \u2014 opens the SQLite DB (use `sqlite3` stdlib), queries `SELECT library.id, track_locations.location, library.bpm, library.rating, library.timesplayed FROM library JOIN track_locations ON library.location = track_locations.id WHERE library.mixxx_deleted = 0` \u2014 returns list of dicts with keys location, bpm, rating, timesplayed. `write_mixxx_crate(db_path: Path, crate_name: str, track_paths: list[Path]) -> int` \u2014 inserts/replaces crate in `crates(name TEXT UNIQUE)`, gets its id, inserts track ids from `track_locations` matching the given paths into `crate_tracks(crate_id, track_id)` (delete existing first). Returns count of tracks written. `sync_all_playlists(db_path: Path, clusters: list[ClusterResult]) -> dict[str, int]` \u2014 calls `write_mixxx_crate` for each cluster, returns {cluster_name: track_count}. (2) In ExportView (TASK-06), enable the [\u21ba Sync with Mixxx] button and wire it to `sync_all_playlists`; if db_path not in config show an `Adw.AlertDialog` asking user to set it. (3) Add 'Mixxx database path' `Adw.EntryRow` to the Preferences window (TASK-03). (4) Add unit tests in tests/unit/test_mixxx_sync.py using an in-memory SQLite DB with the Mixxx schema.",
-      "acceptance_criteria": "tests/unit/test_mixxx_sync.py: write_mixxx_crate on in-memory DB creates a crate row and crate_tracks rows. sync_all_playlists returns a dict. read_mixxx_library returns expected dicts on fixture DB. Sync button enabled in ExportView. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 6,
-      "note": "GitHub issue #81"
-    },
-    {
-      "id": "TASK-26",
-      "epic": "DJ Ecosystem Integration",
-      "title": "rekordbox_xml_import",
-      "owner": "ralph",
-      "description": "Implement Rekordbox XML library import. (1) Create playchitect/core/importers/__init__.py and playchitect/core/importers/rekordbox_import.py. Implement `parse_rekordbox_xml(xml_path: Path) -> list[dict]`: parse the XML using `xml.etree.ElementTree`; iterate `COLLECTION/TRACK` elements; extract: `location` (strip `file://localhost` prefix), `bpm` (float), `key_rekordbox` (str, the Tonality attr), `cue_points` (list of dicts from `POSITION_MARK` children: `{name, position_ms, type}`). Return list of dicts with these keys. Implement `rekordbox_key_to_camelot(key_str: str) -> str` mapping Rekordbox key names (e.g. '6A', '4B', 'Cm', 'G#m') to Camelot strings. (2) Add CLI subcommand `import-rekordbox` to playchitect/cli/commands.py: `@cli.command() def import_rekordbox(xml_path: Path) -> None` \u2014 calls `parse_rekordbox_xml`, prints a summary table of imported tracks. (3) In the app menu (`Adw.MenuButton` from TASK-03) add a 'Import from Rekordbox\u2026' menu item connected to a file picker dialog; on accept call `parse_rekordbox_xml` in a thread. (4) Add a fixture file tests/fixtures/rekordbox_mini.xml (5-track minimal Rekordbox XML). Add unit tests.",
-      "acceptance_criteria": "tests/unit/test_rekordbox_import.py: parse_rekordbox_xml on rekordbox_mini.xml returns 5 dicts with correct keys. rekordbox_key_to_camelot('6A') returns '6A'. `playchitect import-rekordbox --help` shows the command. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 6,
-      "note": "GitHub issue #86"
-    },
-    {
-      "id": "TASK-28",
-      "epic": "Library Management",
-      "title": "vibe_tags_annotation",
-      "owner": "ralph",
-      "description": "Implement user-defined vibe tags for manual track annotation. (1) Create playchitect/core/vibe_tags.py. Implement `VibeTagStore`: `__init__(store_path: Path = Path.home() / '.local' / 'share' / 'playchitect' / 'vibe_tags.json')`; internally a `dict[str, list[str]]` (path_str \u2192 tags). Methods: `load() -> None`, `save() -> None`, `add_tag(track_path: Path, tag: str) -> None` (normalise to lowercase stripped), `remove_tag(track_path: Path, tag: str) -> None`, `get_tags(track_path: Path) -> list[str]`, `search_by_tag(tag: str) -> list[Path]`, `all_tags() -> list[str]` (unique sorted). (2) In `TrackPreviewPanel` (TASK-07), below the key info row add a tag section: a `Gtk.FlowBox` of `Gtk.Button` chips (each chip = tag text + '\u00d7' to dismiss, connected to `remove_tag`). Below: a `Gtk.Entry` for new tag input with auto-complete via `Gtk.EntryCompletion` backed by `all_tags()`. Enter commits via `add_tag`. (3) In LibraryView (TASK-04), add a 'Tags' column showing `', '.join(get_tags(path))` (truncated to 30 chars). (4) Add a tag filter `Gtk.SearchEntry` labelled 'Filter by tag' in LibraryView toolbar area. Add unit tests for VibeTagStore.",
-      "acceptance_criteria": "tests/unit/test_vibe_tags.py: add_tag, remove_tag, search_by_tag, get_tags all work correctly. Tags persist across load/save round-trip. TrackPreviewPanel smoke test shows FlowBox child. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 7,
-      "note": "GitHub issue #87"
-    },
-    {
-      "id": "TASK-32",
-      "epic": "DJ Ecosystem Integration",
-      "title": "audio_structural_analysis_cue_injection",
-      "owner": "ralph",
-      "description": "Implement audio structural analysis to predict mix points and inject cues into Mixxx. (1) Create playchitect/core/structural_analyzer.py. Implement `StructuralAnalyzer` with `analyze(filepath: Path, metadata: TrackMetadata) -> StructuralAnalysis` where `StructuralAnalysis` is a dataclass with fields: `intro_end_ms: float`, `outro_start_ms: float`, `breakdowns: list[float]`, `drops: list[float]`. Use librosa to detect energy-based boundaries: compute RMS energy with `librosa.feature.rms`, find the first frame where energy exceeds 20% of peak (intro end), find the last frame where energy exceeds 20% of peak (outro start). Detect drops as local maxima in the RMS envelope above the 75th percentile. (2) Implement `predict_cue_points(analysis: StructuralAnalysis) -> dict[str, float]` returning `{'cue_1_ms': intro_end_ms, 'cue_2_ms': outro_start_ms}`. (3) In `MixxxSync` (mixxx_sync.py), add `write_cue_points(db_path: Path, track_path: Path, cue_points: dict[str, float]) -> int` that inserts/replaces rows in the `cues` table (`type=1` for hot cues): `INSERT OR REPLACE INTO cues (track_id, type, position, length, hotcue, label) VALUES (?, 1, ?, 0, ?, ?)` where position is in samples at 44100 Hz. (4) In `TrackPreviewPanel` (track_preview_panel.py), add an 'Apply Suggested Cues' `Gtk.Button` that calls `StructuralAnalyzer().analyze()` then `write_cue_points()` in a background thread; show a spinner while running and a toast on completion. (5) Add unit tests in tests/unit/test_structural_analyzer.py using synthetic audio fixtures.",
-      "acceptance_criteria": "tests/unit/test_structural_analyzer.py: analyze() on a synthetic audio fixture returns a StructuralAnalysis with intro_end_ms and outro_start_ms as positive floats. predict_cue_points returns a dict with 'cue_1_ms' and 'cue_2_ms'. write_cue_points on an in-memory Mixxx DB inserts rows into the cues table. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 7,
-      "note": "GitHub issue #82. Relates to #79, #81 (Mixxx sync)."
-    },
-    {
-      "id": "BUG-01",
-      "epic": "GUI Stability",
-      "title": "fix_preview_panel_not_updating_on_track_reselect",
-      "owner": "ralph",
-      "description": "Fix double-emission regression introduced by PR #189.\n\nCURRENT BUG: In library_view.py, _on_activate now fires on EVERY row click, including clicks on different rows where selection-changed also fires. This means load_track() in main_window.py is called twice per click on a different track \u2014 a performance regression.\n\nREQUIRED FIX: Add a deduplication guard so _on_activate only emits when selection-changed has NOT already emitted for the same click:\n\nIn LibraryView.__init__, add: self._selection_change_pending = False\n\nIn _on_selection_changed, set the flag before emitting:\n    self._selection_change_pending = True\n    self.emit(\"track-selected\", item)\n\nIn _on_activate, check and clear the flag:\n    if self._selection_change_pending:\n        self._selection_change_pending = False\n        return  # selection-changed already emitted, skip duplicate\n    item = self._selection.get_selected_item()\n    if item is not None:\n        self.emit(\"track-selected\", item)\n\nAlso rename  to  in _on_activate since it is unused.\nRemove \"BUG-01 Fix:\" tag from the docstring.",
-      "acceptance_criteria": "Clicking a DIFFERENT track emits track-selected exactly ONCE. Clicking the SAME (already selected) track emits track-selected once. Add a test that simulates both selection-changed AND activate firing for the same click and asserts track-selected is emitted only once. All 1201 tests pass.",
-      "completed": true,
-      "priority": 1,
-      "note": "GitHub issue #187",
-      "files": [
-        "playchitect/gui/views/library_view.py",
-        "tests/gui/test_library_view.py"
-      ]
-    },
-    {
-      "id": "BUG-02",
-      "epic": "GUI Stability",
-      "title": "fix_duplicate_tracks_in_playlists",
-      "owner": "ralph",
-      "description": "The clustering output can assign the same track to multiple clusters (e.g. when it sits equidistant between centroids), and there is no deduplication pass. Add a post-clustering deduplication step: after cluster assignment, for each track that appears in more than one cluster, keep it only in the cluster whose centroid it is closest to and remove it from others. This should be applied in clustering.py before returning ClusterResult objects to the UI.",
-      "acceptance_criteria": "No track filepath appears more than once across all ClusterResult.tracks lists. tests/unit/test_clustering.py: add test with a dataset designed to produce overlaps and assert no duplicates in output. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 1,
-      "note": "GitHub issue #191",
-      "files": [
-        "playchitect/core/clustering.py"
-      ]
-    },
-    {
-      "id": "BUG-03",
-      "epic": "GUI Stability",
-      "title": "fix_key_detection_returning_8b_for_all_tracks",
-      "owner": "ralph",
-      "description": "All tracks in the Playlists view are showing Key '8B'. Investigate: (1) Is key detection running at all, or is a default/fallback being returned? (2) Check playchitect/core/metadata_extractor.py and any key detection module for where the key field is populated. (3) If key detection relies on a library (e.g. librosa, keyfinder) that is not running correctly, fix the detection pipeline. (4) If the key column is populated from a tag that is missing on most files, fall back gracefully to None and display '\u2014' rather than a wrong value.",
-      "acceptance_criteria": "Tracks with known keys (verifiable via a reference tool) display the correct key notation. Tracks with no detectable key display '\u2014' not a hardcoded fallback. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 1,
-      "note": "GitHub issue #193",
-      "files": [
-        "playchitect/core/metadata_extractor.py",
-        "playchitect/gui/views/playlists_view.py"
-      ]
-    },
-    {
-      "id": "BUG-04",
-      "epic": "GUI Stability",
-      "title": "fix_export_no_playlists_available_after_clustering",
-      "owner": "ralph",
-      "description": "After running clustering in the Playlists view, switching to Export view shows 'No clusters available to export' and the 'Selected only' dropdown shows '(None)'. The Export view is not reading the clustered playlists from app state. Fix the data-flow: after clustering completes, the ClusterResult list must be stored in a shared app-state object that ExportView reads. Also rename all 'cluster' references in ExportView to 'playlist' (see GUI-01).",
-      "acceptance_criteria": "After running clustering, Export view shows all playlist names in the dropdown. Selecting a playlist and exporting produces a valid M3U file. 'Selected only' correctly filters to the chosen playlist. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 1,
-      "note": "GitHub issue #195",
-      "files": [
-        "playchitect/gui/views/export_view.py",
-        "playchitect/gui/windows/main_window.py"
-      ]
-    },
-    {
-      "id": "BUG-05",
-      "epic": "GUI Stability",
-      "title": "fix_layout_overflow_and_column_resizing",
-      "owner": "ralph",
-      "description": "Multiple views overflow the screen width: Library view is too wide even with no tracks; Preview panel is too wide; Playlists view overflows due to the number of controls in the action bar. Also, columns in the Library ColumnView are not resizable (Gtk.ColumnViewColumn.set_resizable is not set to True). Fix: (1) Set max-width / hexpand=False constraints on panels and action bars. (2) Set resizable=True on all ColumnViewColumn instances in LibraryView. (3) Make the app window double-click-maximisable (check Adw.ApplicationWindow title bar settings). (4) Ensure the Playlists action bar controls wrap or collapse on narrow windows.",
-      "acceptance_criteria": "App fits within a 1920x1080 display without horizontal scrollbars. Library columns are draggable to resize. Double-clicking the title bar maximises the window. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 1,
-      "note": "",
-      "files": [
-        "playchitect/gui/views/library_view.py",
-        "playchitect/gui/views/playlists_view.py",
-        "playchitect/gui/widgets/track_preview_panel.py",
-        "playchitect/gui/windows/main_window.py"
-      ]
-    },
-    {
-      "id": "BUG-06",
-      "epic": "GUI Stability",
-      "title": "fix_mood_classifier_all_ethereal_for_electronic_music",
-      "owner": "ralph",
-      "description": "The rule-based mood classifier in playchitect/core/mood_classifier.py returns 'Ethereal' (the catch-all default at line ~110) for nearly all electronic/techno tracks because the threshold rules for Energetic, Aggressive, Hypnotic etc. are not calibrated for this genre. Review and recalibrate the decision-tree thresholds using typical electronic music feature ranges. In particular: high RMS + high spectral centroid + high percussiveness should resolve to 'Energetic' or 'Aggressive', not fall through to 'Ethereal'. Add unit tests that assert specific mood labels for synthetic feature vectors representative of techno/house/dnb.",
-      "acceptance_criteria": "A synthetic IntensityFeatures with high RMS (>0.1), high percussiveness (>0.5), and high spectral centroid classifies as 'Energetic' or 'Aggressive', not 'Ethereal'. Existing mood classifier tests still pass. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 2,
-      "note": "",
-      "files": [
-        "playchitect/core/mood_classifier.py",
-        "tests/unit/test_mood_classifier.py"
-      ]
-    },
-    {
-      "id": "GUI-01a",
-      "epic": "GUI UX",
-      "title": "rename_cluster_to_playlist_in_views_and_widgets",
-      "owner": "ralph",
-      "description": "Rename all user-facing occurrences of 'Cluster'/'cluster' to 'Playlist'/'playlist' in the GUI view and widget files only. This does NOT require renaming internal Python class names like ClusterResult \u2014 only strings visible to the user: labels, button text, toast notifications, dropdown options, log messages shown in the UI. Files in scope: playlists_view.py, export_view.py, set_builder_view.py, cluster_view.py, cluster_stats.py. Do NOT touch main_window.py or numbering in this task (covered by GUI-01b).",
-      "acceptance_criteria": "No user-visible string in playlists_view.py, export_view.py, set_builder_view.py, cluster_view.py, or cluster_stats.py contains the word 'Cluster' or 'cluster'. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 1,
-      "files": [
-        "playchitect/gui/views/playlists_view.py",
-        "playchitect/gui/views/export_view.py",
-        "playchitect/gui/views/set_builder_view.py",
-        "playchitect/gui/widgets/cluster_view.py",
-        "playchitect/gui/widgets/cluster_stats.py"
-      ],
-      "note": ""
-    },
-    {
-      "id": "GUI-01b",
-      "epic": "GUI UX",
-      "title": "rename_cluster_in_main_window_and_fix_numbering",
-      "owner": "ralph",
-      "description": "Complete the Cluster\u2192Playlist rename in main_window.py (any user-visible strings only, not class names). Also fix playlist numbering from 0-based to 1-based everywhere in the GUI: wherever a playlist index is displayed to the user (e.g. 'Playlist 0', 'Cluster 0'), change to display 'Playlist 1', 'Playlist 2' etc. (index + 1). This applies to playlists_view.py sidebar list, cluster_stats.py headers, and any toast/log messages.",
-      "acceptance_criteria": "No user-visible string in main_window.py contains 'Cluster'/'cluster'. Playlists displayed to the user are numbered starting from 1, not 0. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 1,
-      "files": [
-        "playchitect/gui/windows/main_window.py",
-        "playchitect/gui/views/playlists_view.py",
-        "playchitect/gui/widgets/cluster_stats.py"
-      ],
-      "note": ""
-    },
-    {
-      "id": "FEAT-01a",
-      "epic": "Core Algorithm",
-      "title": "duration_constrained_playlist_assembly_backend",
-      "owner": "ralph",
-      "description": "Implement a new function `build_duration_constrained_playlists(clusters: list[ClusterResult], target_duration_mins: float, tolerance: float = 0.1) -> list[ClusterResult]` in playchitect/core/clustering.py (or a new playchitect/core/playlist_builder.py). The function: (1) For each cluster, ranks its tracks by distance to the cluster centroid (closest first) using the feature vectors already computed. (2) Adds tracks in that order until the cumulative duration reaches target_duration_mins * (1 + tolerance). (3) Any track that doesn't fit its primary cluster is tried against the next-closest cluster's centroid; if it fits there within tolerance, it is added. (4) Returns a new list of ClusterResult objects with trimmed track lists. The target_duration_mins per playlist = user's total set duration / number of playlists.",
-      "acceptance_criteria": "tests/unit/test_playlist_builder.py (or test_clustering.py): add tests asserting that with a 90-min target the output playlist durations are all between 80 and 100 minutes. Function handles edge cases: fewer tracks than needed (returns all available), zero-duration tracks (skipped). uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 1,
-      "files": [
-        "playchitect/core/clustering.py",
-        "playchitect/core/metadata_extractor.py"
-      ],
-      "note": ""
-    },
-    {
-      "id": "FEAT-01b",
-      "epic": "Core Algorithm",
-      "title": "wire_duration_constraint_to_gui",
-      "owner": "ralph",
-      "description": "Wire the duration-constrained playlist assembly (FEAT-01a) into the GUI pipeline. In playchitect/gui/windows/main_window.py, after clustering completes and before results are passed to the PlaylitsView, call `build_duration_constrained_playlists()` with the user's target duration (read from the existing duration control in playlists_view.py or preferences). Ensure the total set duration and number of playlists fields in the UI are clearly labelled and their values are passed through correctly. Add a visible indicator in the Playlists view showing the actual duration of each playlist after trimming.",
-      "acceptance_criteria": "Setting target duration to 60 mins with 4 playlists and generating results in each playlist showing ~60 min of tracks (not the full library). Each playlist row in the sidebar shows its actual duration. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 1,
-      "files": [
-        "playchitect/gui/windows/main_window.py",
-        "playchitect/gui/views/playlists_view.py"
-      ],
-      "note": ""
-    },
-    {
-      "id": "GUI-02",
-      "epic": "GUI UX",
-      "title": "clean_up_header_bar_remove_sushi_arc_fresh",
-      "owner": "ralph",
-      "description": "The global header bar contains three elements that should be moved or removed: (1) 'Sushi \u2713' chip: move this to a small status badge near the Preview panel in LibraryView only; it is irrelevant in other views. (2) 'Arc:' dropdown: this controls energy arc sequencing and belongs in the Playlists view action bar, not the global header. Move it there and enable/disable it based on whether playlists have been generated. (3) 'Fresh:' toggle: this controls track freshness preference and belongs in the Playlists view action bar alongside other sequencing controls. After moving all three, the header bar should contain only the app title/menu and view switcher tabs.",
-      "acceptance_criteria": "Header bar contains no Sushi chip, no Arc dropdown, no Fresh toggle. Arc dropdown appears in Playlists view and is disabled until playlists are generated. Fresh toggle appears in Playlists view. Sushi status appears near the preview panel in Library view. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 1,
-      "note": "",
-      "files": [
-        "playchitect/gui/windows/main_window.py",
-        "playchitect/gui/views/playlists_view.py",
-        "playchitect/gui/views/library_view.py"
-      ]
-    },
-    {
-      "id": "GUI-03",
-      "epic": "GUI UX",
-      "title": "fix_burger_menu_greyed_out_items",
-      "owner": "ralph",
-      "description": "The hamburger menu contains 'Open Folder' and 'Preferences' items that are permanently greyed out and non-functional. Fix: (1) 'Open Folder' should open a Gtk.FileDialog folder picker and trigger a library rescan of the selected folder (wire to the existing scan functionality). (2) 'Preferences' should open the existing PreferencesWindow (playchitect/gui/preferences_window.py). Remove any other greyed-out items that have no planned implementation.",
-      "acceptance_criteria": "Clicking 'Open Folder' opens a folder picker; selecting a folder rescans the library. Clicking 'Preferences' opens the PreferencesWindow. No greyed-out menu items remain unless they have a visible disabled reason (e.g. 'Export \u2014 scan a library first'). uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 2,
-      "note": "",
-      "files": [
-        "playchitect/gui/windows/main_window.py",
-        "playchitect/gui/preferences_window.py"
-      ]
-    },
-    {
-      "id": "GUI-04",
-      "epic": "GUI UX",
-      "title": "merge_sort_and_energy_flow_controls_in_playlists_view",
-      "owner": "ralph",
-      "description": "The Playlists view action bar has two separate dropdowns that are confusingly similar: 'Sort by:' (sequencing algorithm: Energy ramp, BPM ascending, Spectral centroid, Timbre similarity, Intro length) and 'Energy flow:' (arc shape: ramp, build, descent, constant). These are genuinely different axes but are poorly labelled and redundant in effect for most users. Merge them into a single 'Sequence:' control with clear combined options such as: 'Energy ramp', 'Energy build', 'Energy descent', 'BPM ascending', 'BPM descending', 'Timbre similarity' (advanced). Move timbre similarity and intro-length options into a collapsible 'Advanced' expander so the default list is short. Remove the separate Energy flow dropdown.",
-      "acceptance_criteria": "Single 'Sequence:' dropdown replaces both Sort by and Energy flow controls. Advanced options are hidden behind an expander. Selecting any option correctly applies the corresponding sequencing. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 2,
-      "note": "",
-      "files": [
-        "playchitect/gui/views/playlists_view.py"
-      ]
-    },
-    {
-      "id": "GUI-05",
-      "epic": "GUI UX",
-      "title": "add_tooltips_to_all_major_controls",
-      "owner": "ralph",
-      "description": "Most controls in the app have no tooltip. Add Gtk.Widget.set_tooltip_text() to: all dropdown controls (Sequence, Vocal, Key, Playlists count, Duration target), all buttons (Generate, Autofill, Export, Preview), the cluster/playlist graph widget, the energy arc widget, and the Fresh toggle. Tooltips should explain what the control does in plain language appropriate for a DJ user, not an ML engineer.",
-      "acceptance_criteria": "Hovering over each named control for 1 second shows a non-empty tooltip in plain English. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 3,
-      "note": "",
-      "files": [
-        "playchitect/gui/windows/main_window.py",
-        "playchitect/gui/views/playlists_view.py",
-        "playchitect/gui/views/library_view.py",
-        "playchitect/gui/views/export_view.py",
-        "playchitect/gui/views/set_builder_view.py"
-      ]
-    },
-    {
-      "id": "GUI-06",
-      "epic": "GUI UX",
-      "title": "clarify_vocal_filter_options_in_playlists_view",
-      "owner": "ralph",
-      "description": "The Playlists view has a 'Vocal' filter with options 'Any', 'Instrumental', 'Vocal'. These options are confusing for users mixing electronic/techno: (1) Add a tooltip explaining each option and how it affects track selection. (2) Rename options to be clearer: 'Any vocals' \u2192 'Any', 'Instrumental only' \u2192 'No vocals', 'Has vocals' \u2192 'Vocals'. (3) If the vocal detection feature is not reliably implemented, add a note in the tooltip that this filter has limited accuracy for electronic music.",
-      "acceptance_criteria": "Vocal filter has a tooltip explaining its function. Option labels are updated to clearer wording. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 3,
-      "note": "",
-      "files": [
-        "playchitect/gui/views/playlists_view.py"
-      ]
-    },
-    {
-      "id": "FEAT-02",
-      "epic": "Set Builder",
-      "title": "set_builder_chapter_generation",
-      "owner": "ralph",
-      "description": "Redesign the Set Builder view to be chapter-based. A 'chapter' is a named segment of a DJ set with a defined energy role and target duration. When the user clicks 'Generate Set' in the Set Builder view, the app: (1) Runs clustering on the scanned library using energy arc as the primary axis (reusing energy_blocks.py suggest_blocks() which already defines Warm Up / Build / Peak / Sustain / Wind Down blocks). (2) Creates one chapter per block with an auto-generated name (e.g. 'Intro', 'Build', 'Peak', 'Sustain', 'Outro') and a target duration proportional to the user's total set length. (3) Fills each chapter with tracks selected from the corresponding energy block, ranked by centroid proximity, up to the chapter's target duration. (4) Displays the chapters in the Set Builder view as an ordered list of expandable rows. The user can rename any chapter by clicking its name. This uses a separate clustering pass from the Playlists view \u2014 Set Builder and Playlists are independent workflows.",
-      "acceptance_criteria": "Clicking 'Generate Set' with a 90-min target produces 4-6 named chapters whose total duration sums to 80-100 minutes. Each chapter has an auto-generated name. Chapters are displayed as an ordered list in SetBuilderView. Chapter names are editable in-place. tests/unit/test_set_builder.py: add tests for chapter generation. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 2,
-      "note": "",
-      "files": [
-        "playchitect/core/energy_blocks.py",
-        "playchitect/core/arc_sequencer.py",
-        "playchitect/gui/views/set_builder_view.py"
-      ]
-    },
-    {
-      "id": "FEAT-03",
-      "epic": "Set Builder",
-      "title": "set_builder_chapter_interaction",
-      "owner": "ralph",
-      "description": "Build the interaction model for Set Builder chapters: (1) Clicking a chapter row expands it to show its tracks as a sub-list. Within the expanded chapter, tracks can be previewed (spacebar), reordered by drag-and-drop, and individually removed. (2) Clicking outside the expanded chapter collapses it back to summary view. (3) Chapters themselves can be reordered by drag-and-drop in the outer list (the order determines the DJ set narrative arc). (4) An 'Add track' button within each chapter opens a search/filter dialog to pull in a track from the scanned library. (5) Chapter summary row shows: chapter name, track count, total duration, energy range.",
-      "acceptance_criteria": "Chapters expand/collapse on click. Tracks within a chapter can be reordered by drag-and-drop. Chapters themselves can be reordered. Chapter summary correctly reflects track count and total duration after any modifications. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 2,
-      "note": "",
-      "files": [
-        "playchitect/gui/views/set_builder_view.py"
-      ]
-    },
-    {
-      "id": "FEAT-04",
-      "epic": "Set Builder",
-      "title": "set_builder_export",
-      "owner": "ralph",
-      "description": "Add export capability to the Set Builder view with two modes: (1) 'Export as playlist' \u2014 exports all chapters as a single flat M3U file in chapter order, retaining chapter-boundary comments (e.g. #EXTINF chapter markers). (2) 'Export as chapters' \u2014 exports each chapter as a separate M3U file named after the chapter (e.g. '01_Intro.m3u', '02_Build.m3u'). Both export modes prompt the user for an output directory via Gtk.FileDialog. Wire the export button in SetBuilderView to call the existing export infrastructure in playchitect/core/export.py, extending it to support chapter-aware M3U output.",
-      "acceptance_criteria": "'Export as playlist' produces a single M3U with all tracks in chapter order. 'Export as chapters' produces one M3U per chapter with sequential numbering. File names use the chapter names the user has set. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 2,
-      "note": "",
-      "files": [
-        "playchitect/gui/views/set_builder_view.py",
-        "playchitect/core/export.py"
-      ]
-    },
-    {
-      "id": "GUI-07",
-      "epic": "GUI",
-      "title": "maximize_window_on_startup",
-      "owner": "ralph",
-      "description": "Call self.maximize() immediately after self.set_default_size(1000, 700) in PlaychitectWindow.__init__ (playchitect/gui/windows/main_window.py). This makes the app open maximized by default, matching the behaviour of GNOME Music, Nautilus, and other data-heavy GNOME apps. The window must remain user-resizable and must restore correctly if the user un-maximizes it.",
-      "acceptance_criteria": "App opens maximized on first launch. Un-maximizing leaves a 1000x700 fallback size. uv run pytest tests/ -v passes.",
-      "completed": true,
-      "priority": 2,
-      "note": "GitHub issue \u2014 merged PR #212",
-      "files": [
-        "playchitect/gui/windows/main_window.py"
-      ]
-    },
-    {
-      "id": "GUI-08",
-      "epic": "GUI",
-      "title": "brand_css_dark_theme",
-      "owner": "ralph",
-      "description": "Create `playchitect/gui/style.css` with the Playchitect brand colour scheme and load it globally in `playchitect/gui/app.py` via `Gtk.CssProvider.load_from_resource` or `load_from_path`. The CSS must target GTK4/libadwaita widget selectors. Required rules: (1) `window, .background { background-color: #0D1117; }` \u2014 deep navy window and view backgrounds. (2) `.navigation-sidebar, .sidebar-pane { background-color: #111720; }` \u2014 slightly lighter sidebar. (3) `headerbar { background-color: #0D1117; border-bottom: 1px solid #1E2A3A; }`. (4) `button.suggested-action, button.suggested-action:hover { background-color: #7B5CF0; color: #ffffff; border-radius: 6px; }` \u2014 purple primary action buttons (Cluster, Generate Playlists). (5) `.nav-row:selected, row:selected { background-color: rgba(123, 92, 240, 0.25); }` \u2014 purple-tinted selection. (6) `row:hover { background-color: rgba(255,255,255,0.05); }`. (7) `label.title-1, label.title-2 { color: #E6EDF3; }` and `label { color: #C9D1D9; }` for readable text on dark backgrounds. Register the CSS file as a GResource in the build if one exists, otherwise load from the installed path. If libadwaita's `Adw.StyleManager` is already forcing the dark colour-scheme, keep that call and add the custom CSS on top.",
-      "acceptance_criteria": "App window has a deep navy (#0D1117) background rather than the default Adwaita grey. Primary action buttons (Cluster, Generate Playlists) render with a purple (#7B5CF0) fill. Selected nav sidebar row shows a purple-tinted highlight. No white-flash or unstyled flash on startup. `uv run pytest tests/ -v` passes. `uv run pre-commit run --all-files` passes.",
-      "completed": true,
-      "priority": 2,
-      "note": "Stitch design reference: docs/planning/stitch-screens/library-view.png",
-      "files": [
-        "playchitect/gui/app.py",
-        "playchitect/gui/style.css"
-      ]
-    },
-    {
-      "id": "GUI-09",
-      "epic": "GUI",
-      "title": "sidebar_logo_header",
-      "owner": "ralph",
-      "description": "Add the Playchitect logo to the top of the navigation sidebar in `playchitect/gui/windows/main_window.py`. The sidebar is currently an `Adw.OverlaySplitView` with a `Gtk.ListBox` of nav rows. Prepend a non-interactive header widget above the nav rows containing: (1) The app icon loaded from the installed icon theme (`Gtk.Image.new_from_icon_name('com.github.jameswestwood.Playchitect')`, size 48px) or falling back to a `Gtk.Image.new_from_file` pointing at `data/icons/hicolor/48x48/apps/playchitect.png`. (2) A `Gtk.Label` with text 'Playchitect' styled with `label.title-4` CSS class. Wrap both in a `Gtk.Box` (vertical, 8px spacing, 16px top/bottom padding) with CSS class `sidebar-logo-header`. The header must not be selectable as a nav item. No user interaction is required on this widget.",
-      "acceptance_criteria": "The sidebar shows the Playchitect icon and 'Playchitect' wordmark above the Library/Playlists/Set Builder/Export nav rows. Clicking the logo header does not navigate or emit a selection. App still launches and navigates correctly. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 2,
-      "note": "Stitch design reference: docs/planning/stitch-screens/library-view.png",
-      "files": [
-        "playchitect/gui/windows/main_window.py"
-      ]
-    },
-    {
-      "id": "GUI-10",
-      "epic": "GUI",
-      "title": "library_view_tag_chips_and_storage_stats",
-      "owner": "ralph",
-      "description": "Two additions to `playchitect/gui/views/library_view.py` and `playchitect/gui/widgets/track_preview_panel.py`: (1) TAG CHIPS \u2014 when a track is selected and the preview panel is open, display the track's vibe/genre tags as pill-shaped chip labels below the audio player controls. Read tag values from the `TrackMetadata` object (the `tags` or `genre` fields already extracted by `metadata_extractor.py`). Render each non-empty tag as a `Gtk.Label` inside a `Gtk.FlowBox` with CSS class `tag-chip`. Add to `style.css`: `.tag-chip { background-color: rgba(123,92,240,0.2); border: 1px solid #7B5CF0; border-radius: 12px; padding: 2px 10px; font-size: 0.8em; color: #C9D1D9; }`. If the track has no tags, show nothing (do not show an empty FlowBox). (2) STORAGE STATS \u2014 in the library status bar (bottom of the track list pane, where '2,147 tracks in library' is shown), append the total size of all scanned files formatted as 'X.X GB Total'. Compute this by summing `os.path.getsize(track.filepath)` for all tracks in the model, formatted with `/ 1e9` rounded to 1 decimal place. Update the label whenever the track list model changes.",
-      "acceptance_criteria": "Selecting a tagged track (e.g. one with genre='Techno') shows the tag as a purple pill chip below the player. Tracks with no tags show no chip section. The status bar shows e.g. '2,147 tracks \u00b7 48.2 GB Total'. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 2,
-      "note": "Stitch design reference: docs/planning/stitch-screens/library-view.png",
-      "files": [
-        "playchitect/gui/views/library_view.py",
-        "playchitect/gui/widgets/track_preview_panel.py",
-        "playchitect/gui/style.css"
-      ]
-    },
-    {
-      "id": "GUI-11",
-      "epic": "GUI",
-      "title": "playlists_view_stitch_polish",
-      "owner": "ralph",
-      "description": "Four visual improvements to `playchitect/gui/views/playlists_view.py` per the Stitch design: (1) SECTION LABEL \u2014 add a `Gtk.Label` with text 'CURATION QUEUES' (all-caps, small font, muted colour `#8B949E`) above the playlist sidebar list. CSS class `section-header-label`. (2) ENERGY BAR \u2014 each playlist sidebar row already shows track count and duration; add a thin (4px) coloured horizontal `Gtk.LevelBar` or `Gtk.ProgressBar` below the stats showing the average intensity of the playlist (a float 0.0\u20131.0 stored on the playlist object). Style the fill colour purple: `.energy-bar > trough > progress { background-color: #7B5CF0; }`. (3) ENERGY BADGE \u2014 in the right-panel header (next to track count and duration), add a `Gtk.Label` showing '\u26a1 {avg_intensity:.0%} Energy' using the same average intensity value. (4) NEW CURATION BUTTON \u2014 add a `[+ New Curation]` `Gtk.Button` at the bottom of the playlist sidebar list. For now the button opens an `Adw.MessageDialog` with title 'Coming soon' and body 'Manual curation is planned for a future release.' (5) READY TO SYNC LABEL \u2014 in the bottom `Gtk.ActionBar`, after the playlist count label, add a label 'READY TO SYNC' that is only visible once playlists have been generated (i.e. when playlist count > 0).",
-      "acceptance_criteria": "'CURATION QUEUES' label appears above the playlist list. Each playlist row shows an energy intensity bar. The right-panel header shows the energy badge. '+ New Curation' button is present and opens the Coming Soon dialog. 'READY TO SYNC' appears after generating playlists. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 2,
-      "note": "Stitch design reference: docs/planning/stitch-screens/playlists-view.png",
-      "files": [
-        "playchitect/gui/views/playlists_view.py",
-        "playchitect/gui/style.css"
-      ]
-    },
-    {
-      "id": "GUI-12",
-      "epic": "GUI",
-      "title": "set_builder_block_and_card_colors",
-      "owner": "ralph",
-      "description": "Two visual improvements to `playchitect/gui/views/set_builder_view.py` per the Stitch design: (1) ENERGY BLOCK CARD COLORS \u2014 each `EnergyBlockCard` (or equivalent widget in set_builder_view.py) represents a block type (Intro, Build, Peak, Outro). Apply a distinct accent colour to each by adding a CSS class based on block name: `intro-block` \u2192 `#1E6FD9` (blue), `build-block` \u2192 `#7B5CF0` (purple), `peak-block` \u2192 `#E8641A` (orange), `outro-block` \u2192 `#1DAF79` (green). Add these rules to `style.css`. The card border or top-accent strip (3px top border) should use the block colour. The active/selected block card should have a brighter version of its colour as background. (2) TRACK CARD STYLING \u2014 each track card widget in the Set Builder timeline (showing sequence number, title, BPM, energy mini-bar, transition dot) should be styled as a card: `border-radius: 8px; background-color: #161B22; border: 1px solid #1E2A3A; padding: 6px 10px;` with CSS class `track-card`. The energy mini-bar inside each card should use the parent block's accent colour. If the track cards are currently rendered as `Gtk.ListBox` rows, apply the `card` CSS class from libadwaita instead.",
-      "acceptance_criteria": "Intro block card has a blue accent, Build purple, Peak orange, Outro green. Track cards in the timeline have a dark card background with rounded corners. The visual distinction between block types is clear at a glance. `uv run pytest tests/ -v` passes.",
-      "completed": true,
-      "priority": 2,
-      "note": "Stitch design reference: docs/planning/stitch-screens/set-builder-view.png",
-      "files": [
-        "playchitect/gui/views/set_builder_view.py",
-        "playchitect/gui/style.css"
-      ]
-    },
-    {
-      "id": "FEAT-H1",
-      "epic": "Branding",
-      "title": "app_branding_icons_splash_theming",
-      "owner": "human",
-      "description": "Design and implement app branding: (1) A distinct app icon (SVG source + PNG exports at 16/32/48/64/128/256px) that communicates 'DJ / music intelligence'. (2) An About dialog (Adw.AboutDialog) with app name, version, description, and license. (3) A loading/splash state shown while the initial library scan runs \u2014 currently the app shows a blank window. (4) Consider a CSS theme tweak (custom accent colour) via Adw.StyleManager. This task requires design decisions from James before ralph can implement the technical parts.",
-      "acceptance_criteria": "App has a recognisable icon in the taskbar and About dialog. Loading state is shown during initial scan. Design assets are approved by James.",
+      "description": "Update docs/guide/cli-reference.md to document the new 'playlist' command. Read UPDATING_DOCS.md first to understand how VitePress pages are structured and whether the sidebar config in docs/.vitepress/config.ts needs updating.\n\nAdd a new top-level section '## playlist' to docs/guide/cli-reference.md after the existing 'scan' and 'info' sections.\n\nSection content:\n\n## playlist\n\nGenerate a playlist of tracks similar to a seed track, filled to a target length.\n\n```\nplaychitect playlist --seed TRACK --music-dir DIR --duration MINS [OPTIONS]\n```\n\n### Options\n\n| Option | Type | Default | Description |\n|--------|------|---------|-------------|\n| `--seed` | Path | required | Path to the seed track. The seed is always included in the playlist. |\n| `--music-dir` | Path | required | Music library directory to search for similar tracks. |\n| `--duration` | float | required | Target playlist length in minutes (must be > 0). |\n| `--output`, `-o` | Path | auto | Output file path (.m3u or .cue). Defaults to `<music-dir>/Like_<seed_stem>.m3u`. |\n| `--sequence` | choice | `ramp` | Energy sequencing strategy: `ramp`, `build`, `descent`, `alternating`, `bpm_asc`, `bpm_desc`. |\n| `--genre` | text | none | Genre hint for feature weighting: `techno`, `house`, `ambient`, `dnb`. |\n\n### Example\n\n```bash\n# Generate 90 minutes of tracks similar to a seed, saved to ~/Music/Like_strings.m3u\nuv run playchitect playlist \\\n  --seed ~/Music/Strings\\ of\\ Life.flac \\\n  --music-dir ~/Music \\\n  --duration 90\n\n# Export as CUE sheet with a peak energy arc\nuv run playchitect playlist \\\n  --seed ~/Music/seed.flac \\\n  --music-dir ~/Music \\\n  --duration 60 \\\n  --sequence peak \\\n  --output /tmp/myset.cue\n```\n\n### How it works\n\nPlaychitect extracts an 8-dimensional feature vector for each track (BPM + RMS energy + spectral brightness + sub-bass + kick + harmonics + percussiveness + onset strength), scales all vectors with a StandardScaler, applies genre-aware feature weights, then ranks candidates by weighted Euclidean distance from the seed. The closest tracks are greedily added until the target duration is reached (±10%). The resulting playlist is sequenced by the chosen energy strategy.\n\nAlso check docs/.vitepress/config.ts: if the cli-reference page is listed in the sidebar items array, no change is needed (the new section is within the existing page). If it is not listed, add it following the pattern of existing guide pages.",
+      "acceptance_criteria": "docs/guide/cli-reference.md contains a '## playlist' section with the synopsis, options table, example, and how-it-works paragraph. If docs/.vitepress/config.ts needed updating, it is updated. uv run pre-commit run --all-files passes.",
       "completed": false,
-      "priority": 3,
-      "note": ""
-    },
-    {
-      "id": "TASK-H2",
-      "epic": "Research",
-      "title": "realtime_next_track_sidecar_feasibility",
-      "owner": "human",
-      "description": "Research whether a real-time 'Next Track' sidecar integration with Mixxx is feasible. Mixxx exposes a DBus API and/or a TCP control interface. A sidecar process could listen to the currently playing track, query the Playchitect clustering results, and suggest the next track in real-time. Deliverable: a short feasibility note in docs/research/ covering the Mixxx API surface, latency constraints, and recommended implementation approach.",
-      "completed": false,
-      "priority": 3,
-      "note": "GitHub issue #84"
-    },
-    {
-      "id": "TASK-H1",
-      "epic": "Distribution",
-      "title": "flathub_submission",
-      "owner": "human",
-      "description": "Manually submit Playchitect to Flathub following the Flathub submission guide. The Flatpak manifest must be written and the submission PR must be opened by James (not by an AI tool) per Flathub's AI policy. See CLAUDE.md for the full policy note.",
-      "completed": false,
-      "priority": 3,
-      "note": "GitHub issue #60"
+      "priority": 7
     }
   ]
 }


### PR DESCRIPTION
Adds a versioned planning doc decomposing #219 (seed-based length-targeted playlist generation) into epics and granular, junior-ready issues.

Each issue specifies its deliverable, code to reuse, TDD tests, smoke/human testing, and the CLI/GUI/docs updates it needs. Includes a shared Definition of Done, suggested delivery order, and PR slicing.

Doc: `docs/planning/seed-playlist-feature.md`

Refs #219