### PR TITLE
feat(features): add build_feature_vector helper (TASK-01 + TASK-02)

### DIFF
--- a/playchitect/core/features.py
+++ b/playchitect/core/features.py
@@ -1,0 +1,51 @@
+"Shared 8-D feature vector construction for clustering and similarity ranking."
+
+import logging
+
+import numpy as np
+
+from playchitect.core.intensity_analyzer import IntensityFeatures
+from playchitect.core.metadata_extractor import TrackMetadata
+from playchitect.core.weighting import (
+    FEATURE_NAMES,  # noqa: F401  # authoritative ordering reference
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["build_feature_vector"]
+
+
+def build_feature_vector(
+    metadata: TrackMetadata,
+    features: IntensityFeatures | None,
+) -> np.ndarray | None:
+    """Build an 8-D feature vector from metadata and intensity features.
+
+    The 8 values are, in order matching FEATURE_NAMES:
+    bpm, rms_energy, brightness, sub_bass_energy, kick_energy,
+    bass_harmonics, percussiveness, onset_strength.
+
+    Args:
+        metadata: Track metadata containing BPM.
+        features: Intensity analysis features (7 audio features).
+
+    Returns:
+        An 8-element numpy array, or None if BPM is missing or features
+        is None. The returned array is a copy safe for mutation.
+    """
+    if metadata.bpm is None or features is None:
+        return None
+
+    return np.array(
+        [
+            metadata.bpm,
+            features.rms_energy,
+            features.brightness,
+            features.sub_bass_energy,
+            features.kick_energy,
+            features.bass_harmonics,
+            features.percussiveness,
+            features.onset_strength,
+        ],
+        dtype=float,
+    ).copy()

--- a/playchitect/core/playlist_builder.py
+++ b/playchitect/core/playlist_builder.py
@@ -15,6 +15,9 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from playchitect.core.clustering import ClusterResult
+from playchitect.core.features import (
+    build_feature_vector,  # noqa: F401  # used by TASK-06 seed_playlist
+)
 from playchitect.core.intensity_analyzer import IntensityFeatures
 from playchitect.core.metadata_extractor import TrackMetadata
 

--- a/tests/unit/test_feature_vector.py
+++ b/tests/unit/test_feature_vector.py
@@ -9,13 +9,9 @@ from playchitect.core.intensity_analyzer import IntensityFeatures
 from playchitect.core.metadata_extractor import TrackMetadata
 
 
-def make_metadata(
-    name: str, bpm: float | None = 128.0, duration: float = 360.0
-) -> TrackMetadata:
+def make_metadata(name: str, bpm: float | None = 128.0, duration: float = 360.0) -> TrackMetadata:
     """Create TrackMetadata for testing."""
-    return TrackMetadata(
-        filepath=Path(name), bpm=bpm, duration=duration
-    )
+    return TrackMetadata(filepath=Path(name), bpm=bpm, duration=duration)
 
 
 def make_intensity(

--- a/tests/unit/test_feature_vector.py
+++ b/tests/unit/test_feature_vector.py
@@ -1,0 +1,111 @@
+"""Tests for playchitect.core.features.build_feature_vector."""
+
+from pathlib import Path
+
+import numpy as np
+
+from playchitect.core.features import build_feature_vector
+from playchitect.core.intensity_analyzer import IntensityFeatures
+from playchitect.core.metadata_extractor import TrackMetadata
+
+
+def make_metadata(
+    name: str, bpm: float | None = 128.0, duration: float = 360.0
+) -> TrackMetadata:
+    """Create TrackMetadata for testing."""
+    return TrackMetadata(
+        filepath=Path(name), bpm=bpm, duration=duration
+    )
+
+
+def make_intensity(
+    name: str,
+    rms: float = 0.5,
+    brightness: float = 0.5,
+    sub_bass: float = 0.3,
+    kick: float = 0.6,
+    harmonics: float = 0.4,
+    perc: float = 0.5,
+    onset: float = 0.5,
+) -> IntensityFeatures:
+    """Create IntensityFeatures for testing."""
+    return IntensityFeatures(
+        file_path=Path(name),
+        file_hash="deadbeef",  # pragma: allowlist secret
+        rms_energy=rms,
+        brightness=brightness,
+        sub_bass_energy=sub_bass,
+        kick_energy=kick,
+        bass_harmonics=harmonics,
+        percussiveness=perc,
+        onset_strength=onset,
+        camelot_key="8B",
+        key_index=0.0,
+    )
+
+
+class TestBuildFeatureVector:
+    """Tests for build_feature_vector(metadata, features) -> np.ndarray | None."""
+
+    def test_returns_array_of_length_8(self) -> None:
+        """The returned array must have exactly 8 elements."""
+        meta = make_metadata("track1.mp3", bpm=128.0)
+        feats = make_intensity("track1.mp3")
+        result = build_feature_vector(meta, feats)
+        assert result is not None
+        assert isinstance(result, np.ndarray)
+        assert len(result) == 8
+
+    def test_correct_ordering_matches_feature_names(self) -> None:
+        """The 8 values must match FEATURE_NAMES ordering:
+        bpm, rms_energy, brightness, sub_bass_energy, kick_energy,
+        bass_harmonics, percussiveness, onset_strength.
+        """
+        meta = make_metadata("track1.mp3", bpm=128.0)
+        feats = make_intensity(
+            "track1.mp3",
+            rms=0.1,
+            brightness=0.2,
+            sub_bass=0.3,
+            kick=0.4,
+            harmonics=0.5,
+            perc=0.6,
+            onset=0.7,
+        )
+        result = build_feature_vector(meta, feats)
+        assert result is not None
+        expected = np.array([128.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
+        np.testing.assert_array_almost_equal(result, expected)
+
+    def test_returns_none_when_bpm_is_none(self) -> None:
+        """Returns None when metadata.bpm is None."""
+        meta = make_metadata("track1.mp3", bpm=None)
+        feats = make_intensity("track1.mp3")
+        result = build_feature_vector(meta, feats)
+        assert result is None
+
+    def test_returns_none_when_features_is_none(self) -> None:
+        """Returns None when features is None."""
+        meta = make_metadata("track1.mp3", bpm=128.0)
+        result = build_feature_vector(meta, None)  # type: ignore[arg-type]
+        assert result is None
+
+    def test_returned_array_is_a_copy(self) -> None:
+        """The returned array is a copy — mutating it does not change
+        the original feature values.
+        """
+        meta = make_metadata("track1.mp3", bpm=128.0)
+        feats = make_intensity("track1.mp3", rms=0.9)
+        result = build_feature_vector(meta, feats)
+        assert result is not None
+        # Mutate the returned array
+        result[0] = 999.0
+        result[1] = 888.0
+        # Original feature values unchanged
+        assert feats.rms_energy == 0.9
+        assert meta.bpm == 128.0
+        # Second call returns original values again
+        result2 = build_feature_vector(meta, feats)
+        assert result2 is not None
+        assert result2[0] == 128.0
+        assert result2[1] == 0.9


### PR DESCRIPTION
## Summary

Implements the `build_feature_vector()` helper in `playchitect/core/features.py` — the single source of truth for constructing 8-D feature vectors (BPM + 7 intensity features) used by clustering and similarity ranking.

## Tasks covered

- **TASK-01**: 5 pytest tests covering correct length (8), ordering matching FEATURE_NAMES, None handling for missing BPM/features, and copy semantics
- **TASK-02**: Implementation in `playchitect/core/features.py` plus import wiring in `playlist_builder.py`

## Acceptance criteria

- [x] `tests/unit/test_feature_vector.py` — all 5 tests pass
- [x] `tests/unit/test_playlist_builder.py` — no regressions (59 tests pass)
- [x] `tests/unit/test_clustering.py` — no regressions
- [x] ruff clean on all changed files
- [x] Returns `None` when `metadata.bpm` is `None` or `features` is `None`
- [x] Returned array is a copy — mutation doesn't affect originals